### PR TITLE
refactor: Remove multiprocessing.freeze_support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           token: ${{ secrets.HPCFLOW_ACTIONS_TOKEN || secrets.GITHUB_TOKEN }}
           # checkout PR source branch (head_ref) if event is pull_request:
           ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
 
       - run: |
           git config user.name hpcflow-actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # PAT of user who has permission to bypass branch
           # protection || or standard GITHUB_TOKEN if running on an external fork (won't

--- a/hpcflow/cli/cli.py
+++ b/hpcflow/cli/cli.py
@@ -1,10 +1,5 @@
 import sys
 
-if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-
 from hpcflow.api import hpcflow
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove multiprocessing.freeze_support from hpcflow/cli/cli.py since present in hpcflow/sdk/__init__.py