### PR TITLE
Revert "Feature/build-pyinstaller-onefolder"

### DIFF
--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -70,37 +70,21 @@ jobs:
           echo "vers is: $vers"
           echo "vers=$vers" >> $env:GITHUB_ENV
 
-      - name: Build with pyinstaller (non Windows, file)
+      - name: Build with pyinstaller (non Windows)
         if: "!contains(matrix.os, 'windows')"
         working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ env.vers }}-${{ matrix.executable_os }} ${{ github.event.inputs.logLevel }} 'onefile'
+        run: ./make.sh hpcflow-${{ env.vers }}-${{ matrix.executable_os }} ${{ github.event.inputs.logLevel }}
 
-      - name: Build with pyinstaller (non Windows, folder)
-        if: "!contains(matrix.os, 'windows')"
-        working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir ${{ github.event.inputs.logLevel }} 'onedir'
-
-      - name: Build with pyinstaller (Windows, file)
+      - name: Build with pyinstaller (Windows)
         if: contains(matrix.os, 'windows')
         working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ env.vers }}-${{ matrix.executable_os }}" -LogLevel ${{ github.event.inputs.logLevel }} -BuildType 'onefile'
+        run: ./make.ps1 -ExeName "hpcflow-${{ env.vers }}-${{ matrix.executable_os }}" -LogLevel ${{ github.event.inputs.logLevel }}
 
-      - name: Build with pyinstaller (Windows, folder)
-        if: contains(matrix.os, 'windows')
-        working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir" -LogLevel ${{ github.event.inputs.logLevel }} -BuildType 'onedir'
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
-          path: pyinstaller/dist/onefile/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
-
-      - name: Upload executable artifact (folder)
-        uses: actions/upload-artifact@v3
-        with:
-          name: hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir
-          path: pyinstaller/dist/onedir/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir
+          path: pyinstaller/dist/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
 
       - name: Upload spec file
         uses: actions/upload-artifact@v3
@@ -114,13 +98,33 @@ jobs:
           name: hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-build
           path: pyinstaller/build/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}
 
-      - name: Run test suite on the frozen app (file)
+      - name: Version check (windows)
+        if: contains(matrix.os, 'windows')
         run: |
-          pyinstaller/dist/onefile/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} test
+          $tag = "${{ env.cur_tag }}"
+          $tagNoV = $tag.trim('v')
+          $hpcflow_vers = pyinstaller/dist/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version
+          $hpcflow_vers_expected = "hpcflow, version $tagNoV"
+          echo $hpcflow_vers
+          echo "$hpcflow_vers_expected"
+          if ($hpcflow_vers -ne $hpcflow_vers_expected) {
+            exit 1
+          }
 
-      - name: Run test suite on the frozen app (folder)
+      - name: Version check (non-windows)
+        if: "!contains(matrix.os, 'windows')"
         run: |
-          pyinstaller/dist/onedir/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }} test
+          tag=${{ env.cur_tag }}
+          tagNoV=${tag:1}
+          hpcflow_vers=$(pyinstaller/dist/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version)
+          hpcflow_vers_expected="hpcflow, version $tagNoV"
+          echo $hpcflow_vers
+          echo $hpcflow_vers_expected
+          [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
+
+      - name: Run test suite on the frozen app
+        run: |
+          pyinstaller/dist/hpcflow-${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} test
 
   build-executables-linux:
     runs-on: ubuntu-latest
@@ -158,25 +162,15 @@ jobs:
           echo "vers is: $vers"
           echo "vers=$vers" >> $GITHUB_ENV
 
-      - name: Build with pyinstaller for CentOS (file)
+      - name: Build with pyinstaller for CentOS
         working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ env.vers }}-linux ${{ github.event.inputs.logLevel }} onefile
+        run: ./make.sh hpcflow-${{ env.vers }}-linux ${{ github.event.inputs.logLevel }}
 
-      - name: Build with pyinstaller for CentOS (folder)
-        working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ env.vers }}-linux-dir ${{ github.event.inputs.logLevel }} onedir
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: hpcflow-${{ env.vers }}-linux
-          path: pyinstaller/dist/onefile/hpcflow-${{ env.vers }}-linux
-
-      - name: Upload executable artifact (folder)
-        uses: actions/upload-artifact@v3
-        with:
-          name: hpcflow-${{ env.vers }}-linux-dir
-          path: pyinstaller/dist/onedir/hpcflow-${{ env.vers }}-linux-dir
+          path: pyinstaller/dist/hpcflow-${{ env.vers }}-linux
 
       - name: Upload spec file
         uses: actions/upload-artifact@v3
@@ -190,10 +184,16 @@ jobs:
           name: hpcflow-${{ env.vers }}-linux-build
           path: pyinstaller/build/hpcflow-${{ env.vers }}-linux
 
-      - name: Run test suite on the frozen app (file)
+      - name: Version check
         run: |
-          pyinstaller/dist/onefile/hpcflow-${{ env.vers }}-linux test
+          tag=${{ env.cur_tag }}
+          tagNoV=${tag:1}
+          hpcflow_vers=$(pyinstaller/dist/hpcflow-${{ env.vers }}-linux --version)
+          hpcflow_vers_expected="hpcflow, version $tagNoV"
+          echo $hpcflow_vers
+          echo $hpcflow_vers_expected
+          [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
 
-      - name: Run test suite on the frozen app (folder)
+      - name: Run test suite on the frozen app
         run: |
-          pyinstaller/dist/onedir/hpcflow-${{ env.vers }}-linux-dir/hpcflow-${{ env.vers }}-linux-dir test
+          pyinstaller/dist/hpcflow-${{ env.vers }}-linux test

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -70,37 +70,21 @@ jobs:
           echo "vers is: $vers"
           echo "vers=$vers" >> $env:GITHUB_ENV
 
-      - name: Build with pyinstaller (non Windows, file)
+      - name: Build with pyinstaller (non Windows)
         if: "!contains(matrix.os, 'windows')"
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }} ${{ github.event.inputs.logLevel }} 'onefile'{% endraw %}
+        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }} ${{ github.event.inputs.logLevel }}{% endraw %}
 
-      - name: Build with pyinstaller (non Windows, folder)
-        if: "!contains(matrix.os, 'windows')"
-        working-directory: {{ pyinstaller_dir }}
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}-dir ${{ github.event.inputs.logLevel }} 'onedir'{% endraw %}
-
-      - name: Build with pyinstaller (Windows, file)
+      - name: Build with pyinstaller (Windows)
         if: contains(matrix.os, 'windows')
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}" -LogLevel ${{ github.event.inputs.logLevel }} -BuildType 'onefile'{% endraw %}
+        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}" -LogLevel ${{ github.event.inputs.logLevel }}{% endraw %}
 
-      - name: Build with pyinstaller (Windows, folder)
-        if: contains(matrix.os, 'windows')
-        working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}-dir" -LogLevel ${{ github.event.inputs.logLevel }} -BuildType 'onedir'{% endraw %}
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
-          path: {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
-
-      - name: Upload executable artifact (folder)
-        uses: actions/upload-artifact@v3
-        with:
-          name: {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}{% endraw %}-dir
-          path: {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}{% endraw %}-dir
+          path: {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
 
       - name: Upload spec file
         uses: actions/upload-artifact@v3
@@ -114,13 +98,33 @@ jobs:
           name: {{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}{% endraw %}-build
           path: {{ pyinstaller_dir }}/build/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}{% endraw %}
 
-      - name: Run test suite on the frozen app (file)
+      - name: Version check (windows)
+        if: contains(matrix.os, 'windows')
         run: |
-          {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} test
+          $tag = "{% raw %}${{ env.cur_tag }}{% endraw %}"
+          $tagNoV = $tag.trim('v')
+          ${{ executable_name }}_vers = {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version
+          ${{ executable_name }}_vers_expected = "{{ executable_name }}, version $tagNoV"
+          echo ${{ executable_name }}_vers
+          echo "${{ executable_name }}_vers_expected"
+          if (${{ executable_name }}_vers -ne ${{ executable_name }}_vers_expected) {
+            exit 1
+          }
 
-      - name: Run test suite on the frozen app (folder)
+      - name: Version check (non-windows)
+        if: "!contains(matrix.os, 'windows')"
         run: |
-          {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}-dir/{% endraw %}{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }}{% endraw %} test
+          tag={% raw %}${{ env.cur_tag }}{% endraw %}
+          tagNoV=${tag:1}
+          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version)
+          {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
+          echo ${{ executable_name }}_vers
+          echo ${{ executable_name }}_vers_expected
+          [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
+
+      - name: Run test suite on the frozen app
+        run: |
+          {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} test
 
   build-executables-linux:
     runs-on: ubuntu-latest
@@ -158,25 +162,15 @@ jobs:
           echo "vers is: $vers"
           echo "vers=$vers" >> $GITHUB_ENV
 
-      - name: Build with pyinstaller for CentOS (file)
+      - name: Build with pyinstaller for CentOS
         working-directory: pyinstaller
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-linux ${{ github.event.inputs.logLevel }}{% endraw %} onefile
+        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-linux ${{ github.event.inputs.logLevel }}{% endraw %}
 
-      - name: Build with pyinstaller for CentOS (folder)
-        working-directory: pyinstaller
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ env.vers }}-linux-dir ${{ github.event.inputs.logLevel }}{% endraw %} onedir
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: {{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux
-          path: {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux
-
-      - name: Upload executable artifact (folder)
-        uses: actions/upload-artifact@v3
-        with:
-          name: {{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux-dir
-          path: {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux-dir
+          path: {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux
 
       - name: Upload spec file
         uses: actions/upload-artifact@v3
@@ -190,10 +184,16 @@ jobs:
           name: {{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux-build
           path: {{ pyinstaller_dir }}/build/{{ executable_name }}-{% raw %}${{ env.vers }}{% endraw %}-linux
 
-      - name: Run test suite on the frozen app (file)
+      - name: Version check
         run: |
-          {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ env.vers }{% endraw %}}-linux test
+          tag={% raw %}${{ env.cur_tag }}{% endraw %}
+          tagNoV=${tag:1}
+          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }{% endraw %}}-linux --version)
+          {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
+          echo ${{ executable_name }}_vers
+          echo ${{ executable_name }}_vers_expected
+          [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
 
-      - name: Run test suite on the frozen app (folder)
+      - name: Run test suite on the frozen app
         run: |
-          {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ env.vers }}-linux-dir/{% endraw %}{{ executable_name }}-{% raw %}${{ env.vers }}-linux-dir{% endraw %} test
+          {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ env.vers }{% endraw %}}-linux test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,44 +183,40 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev
 
-      - name: Build with pyinstaller (non Windows, file)
+      - name: Build with pyinstaller (non Windows)
         if: "!contains(matrix.os, 'windows')"
         working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO 'onefile'
-        
-      - name: Build with pyinstaller (non Windows, folder)
-        if: "!contains(matrix.os, 'windows')"
-        working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name}}-${{ matrix.executable_os }}-dir $ INFO 'onedir'
+        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO
 
-      - name: Build with pyinstaller (Windows, file)
+      - name: Build with pyinstaller (Windows)
         if: contains(matrix.os, 'windows')
         working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO 'onefile'
+        run: ./make.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO
 
-      - name: Build with pyinstaller (Windows, folder)
-        if: contains(matrix.os, 'windows')
-        working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -LogLevel INFO -BuildType 'onedir'
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
-          path: pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
+          path: pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
 
-      - name: Upload executable artifact (folder)
+      - name: Upload spec file
         uses: actions/upload-artifact@v3
         with:
-          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir
-          path: pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir
+          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}.spec
+          path: pyinstaller/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}.spec
 
-      - name: Version check (windows, file)
+      - name: Upload build directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-build
+          path: pyinstaller/build/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}
+
+      - name: Version check (windows)
         if: contains(matrix.os, 'windows')
         run: |
           $tag = "${{ needs.bump-version.outputs.new_tag_name }}"
           $tagNoV = $tag.trim('v')
-          $hpcflow_vers = pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version
+          $hpcflow_vers = pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version
           $hpcflow_vers_expected = "hpcflow, version $tagNoV"
           echo $hpcflow_vers
           echo "$hpcflow_vers_expected"
@@ -228,48 +224,20 @@ jobs:
             exit 1
           }
 
-      - name: Version check (windows, folder)
-        if: contains(matrix.os, 'windows')
-        run: |
-          $tag = "${{ needs.bump-version.outputs.new_tag_name }}"
-          $tagNoV = $tag.trim('v')
-          $hpcflow_vers = pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}$-dir/{$ endraw %}{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }}  --version
-          $hpcflow_vers_expected = "hpcflow, version $tagNoV"
-          echo $hpcflow_vers
-          echo "$hpcflow_vers_expected"
-          if ($hpcflow_vers -ne $hpcflow_vers_expected) {
-            exit 1
-          }
-
-      - name: Version check (non-windows, file)
+      - name: Version check (non-windows)
         if: "!contains(matrix.os, 'windows')"
         run: |
           tag=${{ needs.bump-version.outputs.new_tag_name }}
           tagNoV=${tag:1}
-          hpcflow_vers=$(pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version)
+          hpcflow_vers=$(pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} --version)
           hpcflow_vers_expected="hpcflow, version $tagNoV"
           echo $hpcflow_vers
           echo $hpcflow_vers_expected
           [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
 
-      - name: Version check (non-windows, folder)
-        if: "!contains(matrix.os, 'windows')"
+      - name: Run test suite on the frozen app
         run: |
-          tag=${{ needs.bump-version.outputs.new_tag_name }}
-          tagNoV=${tag:1}
-          hpcflow_vers=$(pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }} --version)
-          hpcflow_vers_expected="hpcflow, version $tagNoV"
-          echo $hpcflow_vers
-          echo $hpcflow_vers_expected
-          [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
-
-      - name: Run test suite on the frozen app (file)
-        run: |
-          pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} test
-
-      - name: Run test suite on the frozen app (folder)
-        run: |
-          pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }} test
+          pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }} test
 
   build-executables-linux:
     runs-on: ubuntu-latest
@@ -299,53 +267,41 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev
 
-      - name: Build with pyinstaller for CentOS (file)
+      - name: Build with pyinstaller for CentOS
         working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux INFO onefile
+        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux INFO
 
-      - name: Build with pyinstaller for CentOS (folder)
-        working-directory: pyinstaller
-        run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir INFO onedir
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
-          path: pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
+          path: pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
 
-      - name: Upload executable artifact (folder)
+      - name: Upload spec file
         uses: actions/upload-artifact@v3
         with:
-          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
-          path: pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir
+          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux.spec
+          path: pyinstaller/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux.spec
 
-      - name: Version check (file)
+      - name: Upload build directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-build
+          path: pyinstaller/build/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
+
+      - name: Version check
         run: |
           tag=${{ needs.bump-version.outputs.new_tag_name }}
           tagNoV=${tag:1}
-          hpcflow_vers=$(pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux --version)
+          hpcflow_vers=$(pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux --version)
           hpcflow_vers_expected="hpcflow, version $tagNoV"
           echo $hpcflow_vers
           echo $hpcflow_vers_expected
           [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
 
-      - name: Version check (folder)
+      - name: Run test suite on the frozen app
         run: |
-          tag=${{ needs.bump-version.outputs.new_tag_name }}
-          tagNoV=${tag:1}
-          hpcflow_vers=$(pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir --version)
-          hpcflow_vers_expected="hpcflow, version $tagNoV"
-          echo $hpcflow_vers
-          echo $hpcflow_vers_expected
-          [ "$hpcflow_vers" = "$hpcflow_vers_expected" ]
-
-      - name: Run test suite on the frozen app (file)
-        run: |
-          pyinstaller/dist/onefile/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux test
-
-      - name: Run test suite on the frozen app (folder)
-        run: |
-          pyinstaller/dist/onedir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir test
+          pyinstaller/dist/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux test
 
   release-github-PyPI:
     needs: [bump-version, build-executables, build-executables-linux]
@@ -400,9 +356,6 @@ jobs:
             **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-win.exe
             **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-macOS
             **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux
-            **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-win-dir.zip
-            **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-macOS-dir.zip
-            **/hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-linux-dir.zip
           prerelease: ${{ github.event.pull_request.base.ref == 'develop' }}
 
       - name: Release info
@@ -411,7 +364,7 @@ jobs:
           binaryYaml=$(python3 -c "
           from pathlib import Path
           out_yaml = ''
-          for i in ['win.exe', 'macOS', 'linux', 'win-dir.zip', 'macOS-dir.zip', 'linux-dir.zip']:
+          for i in ['win.exe', 'macOS', 'linux']:
             exe_name = 'hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-' + i
             url = 'https://github.com/hpcflow/hpcflow-new/releases/download/${{ needs.bump-version.outputs.new_tag_name }}/' + exe_name
             out_yaml += exe_name + ': ' + url + '\n'

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -183,44 +183,40 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev
 
-      - name: Build with pyinstaller (non Windows, file)
+      - name: Build with pyinstaller (non Windows)
         if: "!contains(matrix.os, 'windows')"
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO 'onefile'{% endraw %}
-        
-      - name: Build with pyinstaller (non Windows, folder)
-        if: "!contains(matrix.os, 'windows')"
-        working-directory: {{ pyinstaller_dir }}
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name}}-${{ matrix.executable_os }}-dir $ INFO 'onedir'{% endraw %}
+        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO{% endraw %}
 
-      - name: Build with pyinstaller (Windows, file)
+      - name: Build with pyinstaller (Windows)
         if: contains(matrix.os, 'windows')
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO 'onefile'{% endraw %}
+        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO{% endraw %}
 
-      - name: Build with pyinstaller (Windows, folder)
-        if: contains(matrix.os, 'windows')
-        working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -LogLevel INFO -BuildType 'onedir'{% endraw %}
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
-          path: {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
+          path: {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %}
 
-      - name: Upload executable artifact (folder)
+      - name: Upload spec file
         uses: actions/upload-artifact@v3
         with:
-          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}-dir
-          path: {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}-dir
+          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}.spec
+          path: {{ pyinstaller_dir }}/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}.spec
 
-      - name: Version check (windows, file)
+      - name: Upload build directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}-build
+          path: {{ pyinstaller_dir }}/build/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}{% endraw %}
+
+      - name: Version check (windows)
         if: contains(matrix.os, 'windows')
         run: |
           $tag = "{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}"
           $tagNoV = $tag.trim('v')
-          ${{ executable_name }}_vers = {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version
+          ${{ executable_name }}_vers = {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version
           ${{ executable_name }}_vers_expected = "{{ executable_name }}, version $tagNoV"
           echo ${{ executable_name }}_vers
           echo "${{ executable_name }}_vers_expected"
@@ -228,48 +224,20 @@ jobs:
             exit 1
           }
 
-      - name: Version check (windows, folder)
-        if: contains(matrix.os, 'windows')
-        run: |
-          $tag = "{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}"
-          $tagNoV = $tag.trim('v')
-          ${{ executable_name }}_vers = {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}$-dir/{$ endraw %}{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }} {% endraw %} --version
-          ${{ executable_name }}_vers_expected = "{{ executable_name }}, version $tagNoV"
-          echo ${{ executable_name }}_vers
-          echo "${{ executable_name }}_vers_expected"
-          if (${{ executable_name }}_vers -ne ${{ executable_name }}_vers_expected) {
-            exit 1
-          }
-
-      - name: Version check (non-windows, file)
+      - name: Version check (non-windows)
         if: "!contains(matrix.os, 'windows')"
         run: |
           tag={% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}
           tagNoV=${tag:1}
-          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version)
+          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} --version)
           {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
           echo ${{ executable_name }}_vers
           echo ${{ executable_name }}_vers_expected
           [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
 
-      - name: Version check (non-windows, folder)
-        if: "!contains(matrix.os, 'windows')"
+      - name: Run test suite on the frozen app
         run: |
-          tag={% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}
-          tagNoV=${tag:1}
-          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir/{% endraw %}{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }}{% endraw %} --version)
-          {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
-          echo ${{ executable_name }}_vers
-          echo ${{ executable_name }}_vers_expected
-          [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
-
-      - name: Run test suite on the frozen app (file)
-        run: |
-          {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} test
-
-      - name: Run test suite on the frozen app (folder)
-        run: |
-          {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir/{% endraw %}{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir${{ matrix.executable_ext }}{% endraw %} test
+          {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}{% endraw %} test
 
   build-executables-linux:
     runs-on: ubuntu-latest
@@ -299,53 +267,41 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev
 
-      - name: Build with pyinstaller for CentOS (file)
+      - name: Build with pyinstaller for CentOS
         working-directory: pyinstaller
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-linux INFO onefile{% endraw %}
+        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-linux INFO{% endraw %}
 
-      - name: Build with pyinstaller for CentOS (folder)
-        working-directory: pyinstaller
-        run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-linux-dir INFO onedir{% endraw %}
-
-      - name: Upload executable artifact (file)
+      - name: Upload executable artifact
         uses: actions/upload-artifact@v3
         with:
           name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
-          path: {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
+          path: {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
 
-      - name: Upload executable artifact (folder)
+      - name: Upload spec file
         uses: actions/upload-artifact@v3
         with:
-          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
-          path: {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux-dir
+          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux.spec
+          path: {{ pyinstaller_dir }}/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux.spec
 
-      - name: Version check (file)
+      - name: Upload build directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux-build
+          path: {{ pyinstaller_dir }}/build/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
+
+      - name: Version check
         run: |
           tag={% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}
           tagNoV=${tag:1}
-          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux --version)
+          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux --version)
           {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
           echo ${{ executable_name }}_vers
           echo ${{ executable_name }}_vers_expected
           [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
 
-      - name: Version check (folder)
+      - name: Run test suite on the frozen app
         run: |
-          tag={% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}
-          tagNoV=${tag:1}
-          {{ executable_name }}_vers=$({{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux-dir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux-dir --version)
-          {{ executable_name }}_vers_expected="{{ executable_name }}, version $tagNoV"
-          echo ${{ executable_name }}_vers
-          echo ${{ executable_name }}_vers_expected
-          [ "${{ executable_name }}_vers" = "${{ executable_name }}_vers_expected" ]
-
-      - name: Run test suite on the frozen app (file)
-        run: |
-          {{ pyinstaller_dir }}/dist/onefile/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }{% endraw %}}-linux test
-
-      - name: Run test suite on the frozen app (folder)
-        run: |
-          {{ pyinstaller_dir }}/dist/onedir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }{% endraw %}}-linux-dir/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }{% endraw %}}-linux-dir test
+          {{ pyinstaller_dir }}/dist/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }{% endraw %}}-linux test
 
   release-github-PyPI:
     needs: [bump-version, build-executables, build-executables-linux]
@@ -400,9 +356,6 @@ jobs:
             **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-win.exe
             **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-macOS
             **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux
-            **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-win-dir.zip
-            **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-macOS-dir.zip
-            **/{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-linux-dir.zip
           prerelease: {{ '${{' }} github.event.pull_request.base.ref == '{{ pre_release_branch }}' {{ '}}' }}
 
       - name: Release info
@@ -411,7 +364,7 @@ jobs:
           binaryYaml=$(python3 -c "
           from pathlib import Path
           out_yaml = ''
-          for i in ['win.exe', 'macOS', 'linux', 'win-dir.zip', 'macOS-dir.zip', 'linux-dir.zip']:
+          for i in ['win.exe', 'macOS', 'linux']:
             exe_name = '{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}-' + i
             url = 'https://github.com/{{ org }}/{{ repo }}/releases/download/{% raw %}${{ needs.bump-version.outputs.new_tag_name }}{% endraw %}/' + exe_name
             out_yaml += exe_name + ': ' + url + '\n'

--- a/pyinstaller/make.ps1
+++ b/pyinstaller/make.ps1
@@ -5,5 +5,5 @@
 # 
 # Might need to disable desktop cloud sync. engines during this!
 # 
-param($ExeName = "hpcflow", $LogLevel = "INFO", $BuildType = 'onefile')
-poetry run pyinstaller --log-level=$LogLevel --distpath ./dist/$BuildType --$BuildType --clean -y --name=$ExeName ..\hpcflow\cli\cli.py
+param($ExeName = "hpcflow", $LogLevel = "INFO")
+poetry run pyinstaller --log-level=$LogLevel --onefile --clean -y --name=$ExeName ..\hpcflow\cli\cli.py

--- a/pyinstaller/make.sh
+++ b/pyinstaller/make.sh
@@ -7,9 +7,6 @@
 # 
 EXE_NAME_DEFAULT="hpcflow"
 LOG_LEVEL_DEFAULT="INFO"
-BUILD_TYPE_DEFAULT="onefile"
 EXE_NAME="${1:-$EXE_NAME_DEFAULT}"
 LOG_LEVEL="${2:-$LOG_LEVEL_DEFAULT}"
-BUILD_TYPE="${3:-$BUILD_TYPE_DEFAULT}"
-
-poetry run pyinstaller --log-level=$LOG_LEVEL --distpath ./dist/$BUILD_TYPE --$BUILD_TYPE --clean -y --name=$EXE_NAME ../hpcflow/cli/cli.py
+poetry run pyinstaller --log-level=$LOG_LEVEL --onefile --clean -y --name=$EXE_NAME ../hpcflow/cli/cli.py


### PR DESCRIPTION
Reverts hpcflow/hpcflow-new#268

This seems like the easiest way to remove the botched release from the develop branch (from here: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/reverting-a-pull-request).

This should remove the change log, but I'll need to sort out the tags separately.