### PR TITLE
Extend helper timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,8 +103,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-20.04
+          - ubuntu-18.04
 
     runs-on: ${{ matrix.os }}
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,8 +124,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Connection to github action runner with ssh
+        uses: valeriangalliat/action-sshd-cloudflared@v1
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,15 @@ jobs:
 
   test-CentOS:
     needs: pre-commit
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
     container:
       image: aplowman/centos7-poetry
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,15 +98,7 @@ jobs:
 
   test-CentOS:
     needs: pre-commit
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-20.04
-          - ubuntu-18.04
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     container:
       image: aplowman/centos7-poetry
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,26 +106,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Set ownership
-        run: |
-          # see: https://github.com/actions/runner/issues/2033#issuecomment-1204205989
-          # this is to fix GIT not liking owner of the checkout dir
-          chown -R $(id -u):$(id -g) $PWD
-
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
 
-      - name: Cache the virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ./.venv
-          key: venv-CentOS-test-${{ hashFiles('**/poetry.lock') }}
-
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
-
-      - name: Connection to github action runner with ssh
-        uses: valeriangalliat/action-sshd-cloudflared@v1
 
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,12 @@ jobs:
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
 
+      - name: Cache the virtualenv
+        uses: actions/cache@v3
+        with:
+          path: ./.venv
+          key: venv-CentOS-test-${{ hashFiles('**/poetry.lock') }}
+
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,12 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
+      - name: Set ownership
+        run: |
+          # see: https://github.com/actions/runner/issues/2033#issuecomment-1204205989
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
+
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Run tests
         run: |
           poetry run python -m pytest --verbose --exitfirst

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -323,19 +323,31 @@ def get_helper_logger(app):
 def helper_timeout(app, timeout, controller, logger):
     """Kill the helper due to running duration exceeding the timeout."""
 
-    logger.info(f"Helper exiting due to timeout ({timeout!r}).")
-    pid_info = get_helper_PID(app)
-    if pid_info:
-        pid_file = pid_info[1]
-        logger.info(f"Deleting PID file: {pid_file!r}.")
-        pid_file.unlink()
+    with open("fhadb.txt", "a") as f:
+        f.write(f"\nfhadb - Helper exiting due to timeout")
+        logger.info(f"Helper exiting due to timeout ({timeout!r}).")
+        pid_info = get_helper_PID(app)
+        f.write(f"\nfhadb - pid_info {pid_info}")
+        if pid_info:
+            pid_file = pid_info[1]
+            f.write(f"\nfhadb - pid_info[1] {pid_info[1]}")
+            logger.info(f"Deleting PID file: {pid_file!r}.")
+            pid_file.unlink()
+            f.write(f"\nfhadb - pid_file unlinked... maybe...")
 
-    logger.info(f"Stopping all watchers.")
-    controller.stop()
-    controller.join()
+        f.write(f"\nfhadb - Stopping all watchers")
+        logger.info(f"Stopping all watchers.")
+        f.write(f"\nfhadb - stopping controller")
+        controller.stop()
+        f.write(f"\nfhadb - joining controller")
+        controller.join()
+        f.write(f"\nfhadb - joined... or is it joined?")
 
-    logger.info(f"Deleting watcher file: {str(controller.workflow_dirs_file_path)}")
-    controller.workflow_dirs_file_path.unlink()
+        f.write(f"\nfhadb - Deleting watcher file")
+        logger.info(f"Deleting watcher file: {str(controller.workflow_dirs_file_path)}")
+        f.write(f"\nfhadb - deleted")
+        controller.workflow_dirs_file_path.unlink()
+        f.write(f"\nfhadb - unlinked")
 
     sys.exit(0)
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -344,8 +344,9 @@ def run_helper(
     timeout_check_interval=DEFAULT_TIMEOUT_CHECK,
     watch_interval=DEFAULT_WATCH_INTERVAL,
 ):
-
+    print(f"fhadb - Can I get the helper logger?")
     logger = get_helper_logger(app)
+    print(f"fhadb - Seems like I just did!")
     logger.info(f"fhadb - I am inside the run_helper function")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -358,6 +358,7 @@ def run_helper(
                         logger.info(f"Updataed timeout_check_interval {change}")
                     elif i == 3:
                         watch_interval = float(PID_vars_new[i])
+                        controller.stop()
                         controller = MonitorController(
                             get_watcher_file_path(app), watch_interval, logger
                         )

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -307,6 +307,8 @@ def get_helper_uptime(app):
         logger.info(f"\n\nfhadb - fhadb file:\n{f.read()}\n")
     with open("subprocesstd.log", "r") as f:
         logger.info(f"\n\nfhadb - subprocesstd file:\n{f.read()}\n")
+    with open(get_user_data_dir(app) / "helper_run.log", "r") as f:
+        logger.info(f"\n\nfhadb - helper_run.log file:\n{f.read()}\n")
 
 
 def get_helper_logger(app, log_path=None):

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -369,7 +369,8 @@ def run_helper(
     try:
         while True:
             time_left_s = (end_time - datetime.now()).total_seconds()
-            logger.info(f"fhadb - I am inside the while True loop."
+            logger.info(
+                f"fhadb - I am inside the while True loop."
                 + f"\nTime left: {time_left_s}"
                 + f"\nTimeout: {timeout}"
             )

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -299,6 +299,9 @@ def get_helper_uptime(app):
         logger.info(f"fhadb - command:{proc.cmdline()}")
         logger.info(f"fhadb - status:{proc.status()}")
         logger.info(f"fhadb\n\n")
+        with open("fhadb.txt", "r") as f:
+            fhadb = f.read(f"fhadb - Can I get the helper logger?")
+        logger.info(f"fhadb file:\n{fhadb}\n")
         return uptime
 
 
@@ -344,10 +347,10 @@ def run_helper(
     timeout_check_interval=DEFAULT_TIMEOUT_CHECK,
     watch_interval=DEFAULT_WATCH_INTERVAL,
 ):
-    with (open("fhadb_log")) as fp:
-        fp.write(f"fhadb - Can I get the helper logger?")
+    with open("fhadb.txt", "w") as f:
+        f.write(f"fhadb - Can I get the helper logger?")
         logger = get_helper_logger(app)
-        fp.write(f"fhadb - Seems like I just did!")
+        f.write(f"fhadb - Seems like I just did!")
     logger.info(f"fhadb - I am inside the run_helper function")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -292,7 +292,12 @@ def get_helper_uptime(app):
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
         logger = get_helper_logger(app)
-        logger.info(f"fhadb - Uptime: {uptime}")
+        logger.info(f"fhadb Process info with psutil:\n\n")
+        logger.info(f"fhadb - uptime: {uptime}")
+        logger.info(f"fhadb - exe:{proc.exe()}")
+        logger.info(f"fhadb - cwd:{proc.cwd()}")
+        logger.info(f"fhadb - command:{proc.cmdline()}")
+        logger.info(f"fhadb - status:{proc.status()}")
         return uptime
 
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -124,11 +124,14 @@ def start_helper(
             str(watch_interval),
         ]
 
+        fff = open("subprocesstd.log", "w")
+        # fff=subprocess.DEVNULL
+
         proc = subprocess.Popen(
             args=args,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdin=fff,
+            stdout=fff,
+            stderr=fff,
             **kwargs,
         )
 
@@ -301,12 +304,13 @@ def get_helper_uptime(app):
         logger.info(f"fhadb\n\n")
         return uptime
     with open("fhadb.txt", "r") as f:
-        logger.info(f"fhadb file:\n{f.read()}\n")
+        logger.info(f"\n\nfhadb - fhadb file:\n{f.read()}\n")
+    with open("subprocesstd.log", "r") as f:
+        logger.info(f"\n\nfhadb - subprocesstd file:\n{f.read()}\n")
 
 
-def get_helper_logger(app):
-
-    log_path = get_helper_log_path(app)
+def get_helper_logger(app, log_path=None):
+    log_path = log_path or get_helper_log_path(app)
     logger = logging.getLogger(__name__)
     if not len(logger.handlers):
         logger.setLevel(logging.INFO)
@@ -360,7 +364,9 @@ def run_helper(
 ):
     with open("fhadb.txt", "w") as f:
         f.write(f"fhadb - Can I get the helper logger?")
-        logger = get_helper_logger(app)
+        separate_log_path = get_user_data_dir(app) / "helper_run.log"
+        f.write(f"\nfhadb - New path {separate_log_path}")
+        logger = get_helper_logger(app, separate_log_path)
         f.write(f"\nfhadb - Seems like I just did!")
         f.write(f"\nfhadb - Now I'll write something to the log...")
         logger.info(f"fhadb - I am inside the run_helper function")

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -352,7 +352,7 @@ def run_helper(
         f.write(f"\nfhadb - Seems like I just did!")
         f.write(f"\nfhadb - Now I'll write something to the log...")
         logger.info(f"fhadb - I am inside the run_helper function")
-        f.write(f"\nfhadb - Done, log has been written to!")
+        f.write(f"\nfhadb - Done, log has been written to!... has it, really?")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename
     # this will be atomic - so there will be only one event fired.
@@ -378,14 +378,20 @@ def run_helper(
     # logger = get_helper_logger(app)
     controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
     helper_args = read_helper_args(app)
+    with open("fhadb.txt", "a") as f:
+        f.write(f"\nfhadb - I am about to enter the while True...")
     try:
         while True:
+            with open("fhadb.txt", "a") as f:
+                f.write(f"\nfhadb - I am inside while True!")
             time_left_s = (end_time - datetime.now()).total_seconds()
             logger.info(
                 f"fhadb - I am inside the while True loop."
                 + f"\nTime left: {time_left_s}"
                 + f"\nTimeout: {timeout}"
             )
+            with open("fhadb.txt", "a") as f:
+                f.write(f"\nfhadb - Just wrote to log again... or did I?")
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)
             time.sleep(min(timeout_check_interval_s, time_left_s))
@@ -393,6 +399,8 @@ def run_helper(
             helper_args_new = read_helper_args(app)
             for name, new_val in helper_args_new.items():
                 if new_val != helper_args[name]:
+                    with open("fhadb.txt", "a") as f:
+                        f.write(f"\nfhadb - I detected a change!")
                     change = f"{name} parameter from {helper_args[name]} to {new_val}."
                     helper_args[name] = new_val
                     if name in ["timeout", "timeout_check_interval"]:

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -140,9 +140,9 @@ def start_helper(
             # Make sure that the process is actually running.
             try:
                 time.sleep(0.2)  # Sleep time is necessary for poll to work.
-                pr=proc.poll()
+                pr = proc.poll()
                 logger.info(f"fhadb - poll result: {pr}")
-                procinfo=psutil.Process(proc.pid)
+                procinfo = psutil.Process(proc.pid)
                 logger.info(f"fhadb - proc info: {procinfo}")
                 logger.info(f"Process {proc.pid} successfully running.")
             except psutil.NoSuchProcess:

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -398,7 +398,11 @@ def run_helper(
             )
             with open("fhadb.txt", "a") as f:
                 f.write(f"\nfhadb - Just wrote to log again... or did I?")
+                f.write(
+                    f"\nfhadb - Coming up next time_left_s:{time_left_s}, condition: {(time_left_s <= 0)}"
+                )
             if time_left_s <= 0:
+
                 with open("fhadb.txt", "a") as f:
                     f.write(f"\nfhadb - Time's up! I'm stopping")
                 helper_timeout(app, timeout, controller, logger)

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -103,11 +103,14 @@ def start_helper(
             watch_interval = watch_interval.total_seconds()
 
         args = app.run_time_info.get_invocation_command()
-        logger.info(f"Invocation command:\n\n{args[0]}\n{args[1]}\n")
+        # TODO: This is not ideal, but works for the timebeing...
+        logger.info(f"fhadb - Invocation command:\n\n{args[0]}\n{args[1]}\n")
         if "pytest/__main__.py" in args[-1]:
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
-            logger.info(f"Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
-            # TODO: This is not ideal, but works for the timebeing...
+            logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
+        elif "pytest\__main__.py" in args[-1]:
+            args[-1] = os.path.dirname(getsourcefile(cli)) + "\cli.py"
+            logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
         args += [
             "--config-dir",
             str(app.config.config_directory),
@@ -137,8 +140,10 @@ def start_helper(
             # Make sure that the process is actually running.
             try:
                 time.sleep(0.2)  # Sleep time is necessary for poll to work.
-                proc.poll()
-                psutil.Process(proc.pid)
+                pr=proc.poll()
+                logger.info(f"fhadb - poll result: {pr}")
+                procinfo=psutil.Process(proc.pid)
+                logger.info(f"fhadb - proc info: {procinfo}")
                 logger.info(f"Process {proc.pid} successfully running.")
             except psutil.NoSuchProcess:
                 logger.error(f"Process {proc.pid} failed to start.")

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -383,12 +383,18 @@ def run_helper(
     try:
         while True:
             with open("fhadb.txt", "a") as f:
-                f.write(f"\nfhadb - I am inside while True!")
+                f.write(
+                    f"\nfhadb - I am inside while True loop"
+                    + f"\nTime left: {time_left_s}"
+                    + f"\nTimeout: {timeout}"
+                    + f"\nTimeout-check-interval: {timeout_check_interval_s}"
+                )
             time_left_s = (end_time - datetime.now()).total_seconds()
             logger.info(
                 f"fhadb - I am inside the while True loop."
                 + f"\nTime left: {time_left_s}"
                 + f"\nTimeout: {timeout}"
+                + f"\nTimeout-check-interval: {timeout_check_interval_s}"
             )
             with open("fhadb.txt", "a") as f:
                 f.write(f"\nfhadb - Just wrote to log again... or did I?")

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -300,8 +300,7 @@ def get_helper_uptime(app):
         logger.info(f"fhadb - status:{proc.status()}")
         logger.info(f"fhadb\n\n")
         with open("fhadb.txt", "r") as f:
-            fhadb = f.read(f"fhadb - Can I get the helper logger?")
-        logger.info(f"fhadb file:\n{fhadb}\n")
+            logger.info(f"fhadb file:\n{f.read()}\n")
         return uptime
 
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -103,8 +103,8 @@ def start_helper(
             watch_interval = watch_interval.total_seconds()
 
         args = app.run_time_info.get_invocation_command()
+        logger.info(f"Invocation command:\n\n{args[0]}\n{args[1]}\n")
         if "pytest/__main__.py" in args[-1]:
-            logger.info(f"Invocation command:\n\n{args[0]}\n{args[1]}\n")
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
             logger.info(f"Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
             # TODO: This is not ideal, but works for the timebeing...

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -124,11 +124,11 @@ def start_helper(
 
         logger.info(f"Writing process ID {proc.pid} to file.")
         try:
-            write_helper_args(app,proc.pid,timeout,timeout_check_interval,watch_interval)
-        except FileNotFoundError as err:
-            logger.error(
-                f"Killing helper process. "
+            write_helper_args(
+                app, proc.pid, timeout, timeout_check_interval, watch_interval
             )
+        except FileNotFoundError as err:
+            logger.error(f"Killing helper process. ")
             proc.kill()
             sys.exit(1)
 
@@ -143,9 +143,9 @@ def modify_helper(
     if PID_file.is_file():
         helper_args = read_helper_args(app)
         if (
-            helper_args['timeout'] != timeout
-            or helper_args['timeout_check_interval'] != timeout_check_interval
-            or helper_args['watch_interval'] != watch_interval
+            helper_args["timeout"] != timeout
+            or helper_args["timeout_check_interval"] != timeout_check_interval
+            or helper_args["watch_interval"] != watch_interval
         ):
             logger = get_helper_logger(app)
             logger.info(
@@ -162,7 +162,13 @@ def modify_helper(
                 watch_interval = watch_interval.total_seconds()
 
             try:
-                write_helper_args(app,helper_args['pid'],timeout,timeout_check_interval,watch_interval)
+                write_helper_args(
+                    app,
+                    helper_args["pid"],
+                    timeout,
+                    timeout_check_interval,
+                    watch_interval,
+                )
             except FileNotFoundError as err:
                 sys.exit(1)
         else:
@@ -199,8 +205,7 @@ def write_helper_args(
     except FileNotFoundError as err:
         logger = get_helper_logger(app)
         logger.error(
-            f"Could not write to the PID file {PID_file!r};"
-            f"Exception was: {err!r}"
+            f"Could not write to the PID file {PID_file!r};" f"Exception was: {err!r}"
         )
         print(err)
 
@@ -211,12 +216,12 @@ def read_helper_args(app):
         print("Helper not running!")
         return None
     else:
-        helper_args={}
+        helper_args = {}
         with PID_file.open("rt") as fp:
             for line in fp:
-                (key, val) = line.split(' = ')
+                (key, val) = line.split(" = ")
                 helper_args[key] = float(val)
-        helper_args['pid'] = int(helper_args['pid'])
+        helper_args["pid"] = int(helper_args["pid"])
         return helper_args
 
 
@@ -345,19 +350,19 @@ def run_helper(
                 if helper_args_new[arg] != helper_args[arg]:
                     change = f"{arg} parameter from {helper_args[arg]} to {helper_args_new[arg]}."
                     helper_args[arg] = helper_args_new[arg]
-                    t=helper_args[arg]
+                    t = helper_args[arg]
                     if isinstance(t, timedelta):
                         t_s = t.total_seconds()
                     else:
                         t_s = t
                         t = timedelta(seconds=t_s)
                     # Updates relevant parameters only
-                    if arg == 'timeout':
-                        timeout=t
+                    if arg == "timeout":
+                        timeout = t
                         end_time = start_time + timeout
-                    elif arg == 'timeout_check_interval':
-                        timeout_check_interval_s=t_s
-                    elif arg == 'watch_interval':
+                    elif arg == "timeout_check_interval":
+                        timeout_check_interval_s = t_s
+                    elif arg == "watch_interval":
                         controller.stop()
                         controller = MonitorController(
                             get_watcher_file_path(app), helper_args[arg], logger

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -103,8 +103,8 @@ def start_helper(
             watch_interval = watch_interval.total_seconds()
 
         args = app.run_time_info.get_invocation_command()
-        if 'pytest/__main__.py' in args[-1]:
-            args[-1] = os.path.dirname(getsourcefile(cli)) + '/cli.py'
+        if "pytest/__main__.py" in args[-1]:
+            args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
             # TODO: This is not ideal, but works for the timebeing...
         args += [
             "--config-dir",
@@ -132,8 +132,8 @@ def start_helper(
             write_helper_args(
                 app, proc.pid, timeout, timeout_check_interval, watch_interval
             )
-            #Make sure that the process is actually running.
-            time.sleep(.2)      # Sleep time is necessary for poll to work.
+            # Make sure that the process is actually running.
+            time.sleep(0.2)  # Sleep time is necessary for poll to work.
             poll = proc.poll()
             if poll is None:
                 logger.info(f"Process {proc.pid} successfully running.")
@@ -293,7 +293,9 @@ def get_helper_logger(app):
     if not len(logger.handlers):
         logger.setLevel(logging.INFO)
         f_handler = RotatingFileHandler(log_path, maxBytes=(5 * 2**20), backupCount=3)
-        f_format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        f_format = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
         f_handler.setFormatter(f_format)
         logger.addHandler(f_handler)
 
@@ -363,7 +365,7 @@ def run_helper(
                 if new_val != helper_args[name]:
                     change = f"{name} parameter from {helper_args[name]} to {new_val}."
                     helper_args[name] = new_val
-                    if name in ["timeout","timeout_check_interval"]:
+                    if name in ["timeout", "timeout_check_interval"]:
                         t = helper_args[name]
                         if isinstance(t, timedelta):
                             t_s = t.total_seconds()
@@ -372,9 +374,9 @@ def run_helper(
                         if name == "timeout":
                             timeout = timedelta(seconds=t_s)
                             end_time = start_time + timeout
-                        else: # name == "timeout_check_interval"
+                        else:  # name == "timeout_check_interval"
                             timeout_check_interval_s = t_s
-                    else: # name == "watch_interval"
+                    else:  # name == "watch_interval"
                         controller.stop()
                         # TODO: we might need to consider if a workflow change could be missed during this stop
                         controller = MonitorController(

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -286,21 +286,21 @@ def clear_helper(app):
 
 
 def get_helper_uptime(app):
+    logger = get_helper_logger(app)
+    logger.info(f"fhadb Process info with psutil:\n\n")
+    logger.info(f"fhadb - uptime: {uptime}")
+    logger.info(f"fhadb - exe:{proc.exe()}")
+    logger.info(f"fhadb - cwd:{proc.cwd()}")
+    logger.info(f"fhadb - command:{proc.cmdline()}")
+    logger.info(f"fhadb - status:{proc.status()}")
+    logger.info(f"fhadb\n\n")
+    with open("fhadb.txt", "r") as f:
+        logger.info(f"fhadb file:\n{f.read()}\n")
     pid_info = get_helper_PID(app)
     if pid_info:
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
-        logger = get_helper_logger(app)
-        logger.info(f"fhadb Process info with psutil:\n\n")
-        logger.info(f"fhadb - uptime: {uptime}")
-        logger.info(f"fhadb - exe:{proc.exe()}")
-        logger.info(f"fhadb - cwd:{proc.cwd()}")
-        logger.info(f"fhadb - command:{proc.cmdline()}")
-        logger.info(f"fhadb - status:{proc.status()}")
-        logger.info(f"fhadb\n\n")
-        with open("fhadb.txt", "r") as f:
-            logger.info(f"fhadb file:\n{f.read()}\n")
         return uptime
 
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -277,11 +277,12 @@ def get_helper_logger(app):
 
     log_path = get_helper_log_path(app)
     logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    f_handler = RotatingFileHandler(log_path, maxBytes=(5 * 2**20), backupCount=3)
-    f_format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    f_handler.setFormatter(f_format)
-    logger.addHandler(f_handler)
+    if not len(logger.handlers):
+        logger.setLevel(logging.INFO)
+        f_handler = RotatingFileHandler(log_path, maxBytes=(5 * 2**20), backupCount=3)
+        f_format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        f_handler.setFormatter(f_format)
+        logger.addHandler(f_handler)
 
     return logger
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -108,8 +108,8 @@ def start_helper(
         if "pytest/__main__.py" in args[-1]:
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
             logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
-        elif "pytest\__main__.py" in args[-1]:
-            args[-1] = os.path.dirname(getsourcefile(cli)) + "\cli.py"
+        elif "pytest\\__main__.py" in args[-1]:
+            args[-1] = os.path.dirname(getsourcefile(cli)) + "\\cli.py"
             logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
         args += [
             "--config-dir",
@@ -291,6 +291,8 @@ def get_helper_uptime(app):
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
+        logger = get_helper_logger(app)
+        logger.info(f"fhadb - Uptime: {uptime}")
         return uptime
 
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -344,9 +344,10 @@ def run_helper(
     timeout_check_interval=DEFAULT_TIMEOUT_CHECK,
     watch_interval=DEFAULT_WATCH_INTERVAL,
 ):
-    print(f"fhadb - Can I get the helper logger?")
-    logger = get_helper_logger(app)
-    print(f"fhadb - Seems like I just did!")
+    with (open("fhadb_log")) as fp:
+        fp.write(f"fhadb - Can I get the helper logger?")
+        logger = get_helper_logger(app)
+        fp.write(f"fhadb - Seems like I just did!")
     logger.info(f"fhadb - I am inside the run_helper function")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -121,14 +121,11 @@ def start_helper(
             str(watch_interval),
         ]
 
-        fff = open("subprocesstd.log", "w")
-        # fff=subprocess.DEVNULL
-
         proc = subprocess.Popen(
             args=args,
-            stdin=fff,
-            stdout=fff,
-            stderr=fff,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             **kwargs,
         )
 
@@ -284,7 +281,6 @@ def clear_helper(app):
 
 def get_helper_uptime(app):
     pid_info = get_helper_PID(app)
-    logger = get_helper_logger(app)
     if pid_info:
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -127,6 +127,14 @@ def start_helper(
             write_helper_args(
                 app, proc.pid, timeout, timeout_check_interval, watch_interval
             )
+            #Make sure that the process is actually running.
+            time.sleep(.2)      # Sleep time is necessary for poll to work.
+            poll = proc.poll()
+            if poll is None:
+                logger.info(f"Process {proc.pid} successfully running.")
+            else:
+                logger.error(f"Process {proc.pid} failed to start.")
+                sys.exit(1)
         except FileNotFoundError as err:
             logger.error(f"Killing helper process. ")
             proc.kill()

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -104,7 +104,9 @@ def start_helper(
 
         args = app.run_time_info.get_invocation_command()
         if "pytest/__main__.py" in args[-1]:
+            print(f"\n\n{args[0]}\n{args[1]}\n")
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
+            print(f"\n\n{args[0]}\n{args[1]}\n")
             # TODO: This is not ideal, but works for the timebeing...
         args += [
             "--config-dir",
@@ -133,11 +135,12 @@ def start_helper(
                 app, proc.pid, timeout, timeout_check_interval, watch_interval
             )
             # Make sure that the process is actually running.
-            time.sleep(0.2)  # Sleep time is necessary for poll to work.
-            poll = proc.poll()
-            if poll is None:
+            try:
+                time.sleep(0.2)  # Sleep time is necessary for poll to work.
+                proc.poll()
+                psutil.Process(proc.pid)
                 logger.info(f"Process {proc.pid} successfully running.")
-            else:
+            except psutil.NoSuchProcess:
                 logger.error(f"Process {proc.pid} failed to start.")
                 sys.exit(1)
         except FileNotFoundError as err:

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -104,9 +104,9 @@ def start_helper(
 
         args = app.run_time_info.get_invocation_command()
         if "pytest/__main__.py" in args[-1]:
-            print(f"\n\n{args[0]}\n{args[1]}\n")
+            logger.info(f"Invocation command:\n\n{args[0]}\n{args[1]}\n")
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
-            print(f"\n\n{args[0]}\n{args[1]}\n")
+            logger.info(f"Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
             # TODO: This is not ideal, but works for the timebeing...
         args += [
             "--config-dir",

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -339,6 +339,9 @@ def run_helper(
     watch_interval=DEFAULT_WATCH_INTERVAL,
 ):
 
+    logger = get_helper_logger(app)
+    logger.info(f"fhadb - I am inside the run_helper function")
+
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename
     # this will be atomic - so there will be only one event fired.
     # Also return a local run ID (the position in the file) to be used in jobscript naming
@@ -360,11 +363,14 @@ def run_helper(
 
     start_time = datetime.now()
     end_time = start_time + timeout
-    logger = get_helper_logger(app)
+    # logger = get_helper_logger(app)
     controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
     helper_args = read_helper_args(app)
     try:
         while True:
+            logger.info(f"fhadb - I am inside the while True loop.\n"+
+                        f"Time left: {time_left_s}"+
+                        f"Timeout: {timeout}")
             time_left_s = (end_time - datetime.now()).total_seconds()
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -287,11 +287,11 @@ def clear_helper(app):
 
 def get_helper_uptime(app):
     pid_info = get_helper_PID(app)
+    logger = get_helper_logger(app)
     if pid_info:
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
-        logger = get_helper_logger(app)
         logger.info(f"fhadb Process info with psutil:\n\n")
         logger.info(f"fhadb - uptime: {uptime}")
         logger.info(f"fhadb - exe:{proc.exe()}")

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -399,6 +399,8 @@ def run_helper(
             with open("fhadb.txt", "a") as f:
                 f.write(f"\nfhadb - Just wrote to log again... or did I?")
             if time_left_s <= 0:
+                with open("fhadb.txt", "a") as f:
+                    f.write(f"\nfhadb - Time's up! I'm stopping")
                 helper_timeout(app, timeout, controller, logger)
             time.sleep(min(timeout_check_interval_s, time_left_s))
             # Reading args from PID file

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -104,13 +104,10 @@ def start_helper(
 
         args = app.run_time_info.get_invocation_command()
         # TODO: This is not ideal, but works for the timebeing...
-        logger.info(f"fhadb - Invocation command:\n\n{args[0]}\n{args[1]}\n")
         if "pytest/__main__.py" in args[-1]:
             args[-1] = os.path.dirname(getsourcefile(cli)) + "/cli.py"
-            logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
         elif "pytest\\__main__.py" in args[-1]:
             args[-1] = os.path.dirname(getsourcefile(cli)) + "\\cli.py"
-            logger.info(f"fhadb - Modified invocation command:\n\n{args[0]}\n{args[1]}\n")
         args += [
             "--config-dir",
             str(app.config.config_directory),
@@ -143,10 +140,7 @@ def start_helper(
             # Make sure that the process is actually running.
             try:
                 time.sleep(0.2)  # Sleep time is necessary for poll to work.
-                pr = proc.poll()
-                logger.info(f"fhadb - poll result: {pr}")
-                procinfo = psutil.Process(proc.pid)
-                logger.info(f"fhadb - proc info: {procinfo}")
+                proc.poll()
                 logger.info(f"Process {proc.pid} successfully running.")
             except psutil.NoSuchProcess:
                 logger.error(f"Process {proc.pid} failed to start.")
@@ -295,13 +289,6 @@ def get_helper_uptime(app):
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
-        logger.info(f"fhadb Process info with psutil:\n\n")
-        logger.info(f"fhadb - uptime: {uptime}")
-        logger.info(f"fhadb - exe:{proc.exe()}")
-        logger.info(f"fhadb - cwd:{proc.cwd()}")
-        logger.info(f"fhadb - command:{proc.cmdline()}")
-        logger.info(f"fhadb - status:{proc.status()}")
-        logger.info(f"fhadb\n\n")
         return uptime
     with open("subprocesstd.log", "r") as f:
         logger.info(f"\n\nfhadb - subprocesstd file:\n{f.read()}\n")
@@ -352,7 +339,7 @@ def run_helper(
 
     separate_log_path = get_user_data_dir(app) / "helper_run.log"
     logger = get_helper_logger(app, separate_log_path)
-    logger.info(f"fhadb - I am inside the run_helper function")
+    logger.info(f"fhadb - I am in the other run log.")
     separate_log_path = get_helper_log_path(app)
     logger = get_helper_logger(app, separate_log_path)
     logger.info(f"fhadb - This should be in the new... well, old... log")
@@ -384,12 +371,6 @@ def run_helper(
     try:
         while True:
             time_left_s = (end_time - datetime.now()).total_seconds()
-            logger.info(
-                f"fhadb - I am inside the while True loop."
-                + f"\nTime left: {time_left_s}"
-                + f"\nTimeout: {timeout}"
-                + f"\nTimeout-check-interval: {timeout_check_interval_s}"
-            )
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)
             time.sleep(min(timeout_check_interval_s, time_left_s))

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -176,10 +176,9 @@ def modify_helper(
                     fp.write(f"watch-interval = {watch_interval}\n")
             except FileNotFoundError as err:
                 logger.error(
-                    f"Could not write to the PID file {PID_file!r}; killing helper process. "
+                    f"Could not write to the PID file {PID_file!r};"
                     f"Exception was: {err!r}"
                 )
-                proc.kill()
                 sys.exit(1)
         else:
             print("Helper parameters already met.")

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -368,12 +368,11 @@ def run_helper(
     helper_args = read_helper_args(app)
     try:
         while True:
-            logger.info(
-                f"fhadb - I am inside the while True loop.\n"
-                + f"Time left: {time_left_s}"
-                + f"Timeout: {timeout}"
-            )
             time_left_s = (end_time - datetime.now()).total_seconds()
+            logger.info(f"fhadb - I am inside the while True loop."
+                + f"\nTime left: {time_left_s}"
+                + f"\nTimeout: {timeout}"
+            )
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)
             time.sleep(min(timeout_check_interval_s, time_left_s))

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -368,9 +368,11 @@ def run_helper(
     helper_args = read_helper_args(app)
     try:
         while True:
-            logger.info(f"fhadb - I am inside the while True loop.\n"+
-                        f"Time left: {time_left_s}"+
-                        f"Timeout: {timeout}")
+            logger.info(
+                f"fhadb - I am inside the while True loop.\n"
+                + f"Time left: {time_left_s}"
+                + f"Timeout: {timeout}"
+            )
             time_left_s = (end_time - datetime.now()).total_seconds()
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -349,8 +349,10 @@ def run_helper(
     with open("fhadb.txt", "w") as f:
         f.write(f"fhadb - Can I get the helper logger?")
         logger = get_helper_logger(app)
-        f.write(f"fhadb - Seems like I just did!")
-    logger.info(f"fhadb - I am inside the run_helper function")
+        f.write(f"\nfhadb - Seems like I just did!")
+        f.write(f"\nfhadb - Now I'll write something to the log...")
+        logger.info(f"fhadb - I am inside the run_helper function")
+        f.write(f"\nfhadb - Done, log has been written to!")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename
     # this will be atomic - so there will be only one event fired.

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -420,7 +420,11 @@ def run_helper(
                         controller = MonitorController(
                             get_watcher_file_path(app), helper_args[name], logger
                         )
+                    with open("fhadb.txt", "a") as f:
+                        f.write(f"\nfhadb - I just updated {change}")
                     logger.info(f"Updated {change}")
+                    with open("fhadb.txt", "a") as f:
+                        f.write(f"\nfhadb - And recorded it to the log... in theory...")
 
     except KeyboardInterrupt:
         controller.stop()

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -307,8 +307,10 @@ def get_helper_uptime(app):
         logger.info(f"\n\nfhadb - fhadb file:\n{f.read()}\n")
     with open("subprocesstd.log", "r") as f:
         logger.info(f"\n\nfhadb - subprocesstd file:\n{f.read()}\n")
+    with open(get_helper_log_path(app), "r") as f:
+        logger.info(f"\n\n\n\nfhadb - helper.log file:\n{f.read()}\n")
     with open(get_user_data_dir(app) / "helper_run.log", "r") as f:
-        logger.info(f"\n\nfhadb - helper_run.log file:\n{f.read()}\n")
+        logger.info(f"\n\n\n\nfhadb - helper_run.log file:\n{f.read()}\n")
 
 
 def get_helper_logger(app, log_path=None):

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -290,16 +290,10 @@ def get_helper_uptime(app):
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
         return uptime
-    with open("subprocesstd.log", "r") as f:
-        logger.info(f"\n\nfhadb - subprocesstd file:\n{f.read()}\n")
-    with open(get_helper_log_path(app), "r") as f:
-        logger.info(f"\n\n\n\nfhadb - helper.log file:\n{f.read()}\n")
-    with open(get_user_data_dir(app) / "helper_run.log", "r") as f:
-        logger.info(f"\n\n\n\nfhadb - helper_run.log file:\n{f.read()}\n")
 
 
-def get_helper_logger(app, log_path=None):
-    log_path = log_path or get_helper_log_path(app)
+def get_helper_logger(app):
+    log_path = get_helper_log_path(app)
     logger = logging.getLogger(__name__)
     if not len(logger.handlers):
         logger.setLevel(logging.INFO)
@@ -336,14 +330,6 @@ def run_helper(
     timeout_check_interval=DEFAULT_TIMEOUT_CHECK,
     watch_interval=DEFAULT_WATCH_INTERVAL,
 ):
-
-    separate_log_path = get_user_data_dir(app) / "helper_run.log"
-    logger = get_helper_logger(app, separate_log_path)
-    logger.info(f"fhadb - I am in the other run log.")
-    separate_log_path = get_helper_log_path(app)
-    logger = get_helper_logger(app, separate_log_path)
-    logger.info(f"fhadb - This should be in the new... well, old... log")
-
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename
     # this will be atomic - so there will be only one event fired.
     # Also return a local run ID (the position in the file) to be used in jobscript naming
@@ -365,7 +351,7 @@ def run_helper(
 
     start_time = datetime.now()
     end_time = start_time + timeout
-    # logger = get_helper_logger(app)
+    logger = get_helper_logger(app)
     controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
     helper_args = read_helper_args(app)
     try:

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -375,6 +375,12 @@ def run_helper(
         f.write(f"\nfhadb - Now I'll write something to the log...")
         logger.info(f"fhadb - I am inside the run_helper function")
         f.write(f"\nfhadb - Done, log has been written to!... has it, really?")
+        f.write(f"\nfhadb - Changed my mind, I want to use the same log")
+        separate_log_path = get_helper_log_path(app)
+        f.write(f"\nfhadb - New/old log path {separate_log_path}")
+        logger = get_helper_logger(app, separate_log_path)
+        f.write(f"\nfhadb - Done, should be back in same log")
+        logger.info(f"fhadb - This should be in the new... well, old... log")
 
     # TODO: when writing to watch_workflows from a workflow, copy, modify and then rename
     # this will be atomic - so there will be only one event fired.

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -382,6 +382,7 @@ def run_helper(
         f.write(f"\nfhadb - I am about to enter the while True...")
     try:
         while True:
+            time_left_s = (end_time - datetime.now()).total_seconds()
             with open("fhadb.txt", "a") as f:
                 f.write(
                     f"\nfhadb - I am inside while True loop"
@@ -389,7 +390,6 @@ def run_helper(
                     + f"\nTimeout: {timeout}"
                     + f"\nTimeout-check-interval: {timeout_check_interval_s}"
                 )
-            time_left_s = (end_time - datetime.now()).total_seconds()
             logger.info(
                 f"fhadb - I am inside the while True loop."
                 + f"\nTime left: {time_left_s}"

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -286,22 +286,22 @@ def clear_helper(app):
 
 
 def get_helper_uptime(app):
-    logger = get_helper_logger(app)
-    logger.info(f"fhadb Process info with psutil:\n\n")
-    logger.info(f"fhadb - uptime: {uptime}")
-    logger.info(f"fhadb - exe:{proc.exe()}")
-    logger.info(f"fhadb - cwd:{proc.cwd()}")
-    logger.info(f"fhadb - command:{proc.cmdline()}")
-    logger.info(f"fhadb - status:{proc.status()}")
-    logger.info(f"fhadb\n\n")
-    with open("fhadb.txt", "r") as f:
-        logger.info(f"fhadb file:\n{f.read()}\n")
     pid_info = get_helper_PID(app)
     if pid_info:
         proc = psutil.Process(pid_info[0])
         create_time = datetime.fromtimestamp(proc.create_time())
         uptime = datetime.now() - create_time
+        logger = get_helper_logger(app)
+        logger.info(f"fhadb Process info with psutil:\n\n")
+        logger.info(f"fhadb - uptime: {uptime}")
+        logger.info(f"fhadb - exe:{proc.exe()}")
+        logger.info(f"fhadb - cwd:{proc.cwd()}")
+        logger.info(f"fhadb - command:{proc.cmdline()}")
+        logger.info(f"fhadb - status:{proc.status()}")
+        logger.info(f"fhadb\n\n")
         return uptime
+    with open("fhadb.txt", "r") as f:
+        logger.info(f"fhadb file:\n{f.read()}\n")
 
 
 def get_helper_logger(app):

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -127,8 +127,8 @@ def start_helper(
             write_helper_args(
                 app, proc.pid, timeout, timeout_check_interval, watch_interval
             )
-            #Make sure that the process is actually running.
-            time.sleep(.2)      # Sleep time is necessary for poll to work.
+            # Make sure that the process is actually running.
+            time.sleep(0.2)  # Sleep time is necessary for poll to work.
             poll = proc.poll()
             if poll is None:
                 logger.info(f"Process {proc.pid} successfully running.")
@@ -288,7 +288,9 @@ def get_helper_logger(app):
     if not len(logger.handlers):
         logger.setLevel(logging.INFO)
         f_handler = RotatingFileHandler(log_path, maxBytes=(5 * 2**20), backupCount=3)
-        f_format = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        f_format = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
         f_handler.setFormatter(f_format)
         logger.addHandler(f_handler)
 
@@ -358,7 +360,7 @@ def run_helper(
                 if new_val != helper_args[name]:
                     change = f"{name} parameter from {helper_args[name]} to {new_val}."
                     helper_args[name] = new_val
-                    if name in ["timeout","timeout_check_interval"]:
+                    if name in ["timeout", "timeout_check_interval"]:
                         t = helper_args[name]
                         if isinstance(t, timedelta):
                             t_s = t.total_seconds()
@@ -367,9 +369,9 @@ def run_helper(
                         if name == "timeout":
                             timeout = timedelta(seconds=t_s)
                             end_time = start_time + timeout
-                        else: # name == "timeout_check_interval"
+                        else:  # name == "timeout_check_interval"
                             timeout_check_interval_s = t_s
-                    else: # name == "watch_interval"
+                    else:  # name == "watch_interval"
                         controller.stop()
                         # TODO: we might need to consider if a workflow change could be missed during this stop
                         controller = MonitorController(

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -358,7 +358,9 @@ def run_helper(
                         logger.info(f"Updataed timeout_check_interval {change}")
                     elif i == 3:
                         watch_interval = float(PID_vars_new[i])
-                        controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
+                        controller = MonitorController(
+                            get_watcher_file_path(app), watch_interval, logger
+                        )
                         logger.info(f"Updataed watch_interval {change}")
 
     except KeyboardInterrupt:

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -298,6 +298,7 @@ def get_helper_uptime(app):
         logger.info(f"fhadb - cwd:{proc.cwd()}")
         logger.info(f"fhadb - command:{proc.cmdline()}")
         logger.info(f"fhadb - status:{proc.status()}")
+        logger.info(f"fhadb\n\n")
         return uptime
 
 

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -335,33 +335,31 @@ def run_helper(
                 if PID_vars_new[i] != PID_vars[i]:
                     change = f"parameter from {PID_vars[i]} to {PID_vars_new[i]}."
                     PID_vars[i] = PID_vars_new[i]
-                    match i:
-                        case 1:
-                            timeout = float(PID_vars_new[i])
-                            if isinstance(timeout, timedelta):
-                                timeout_s = timeout.total_seconds()
-                            else:
-                                timeout_s = timeout
-                                timeout = timedelta(seconds=timeout_s)
-                            end_time = start_time + timeout
-                            logger.info(f"Updataed timeout {change}")
-                        case 2:
-                            timeout_check_interval = float(PID_vars_new[i])
-                            if isinstance(timeout_check_interval, timedelta):
-                                timeout_check_interval_s = (
-                                    timeout_check_interval.total_seconds()
-                                )
-                            else:
-                                timeout_check_interval_s = timeout_check_interval
-                                timeout_check_interval = timedelta(
-                                    seconds=timeout_check_interval_s
-                                )
-                            logger.info(f"Updataed timeout_check_interval {change}")
-                        case 3:
-                            watch_interval = float(PID_vars_new[i])
-                            # controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
-                            logger.info(f"Updataed watch_interval {change}")
-                            # Would this work?
+                    if i == 1:
+                        timeout = float(PID_vars_new[i])
+                        if isinstance(timeout, timedelta):
+                            timeout_s = timeout.total_seconds()
+                        else:
+                            timeout_s = timeout
+                            timeout = timedelta(seconds=timeout_s)
+                        end_time = start_time + timeout
+                        logger.info(f"Updataed timeout {change}")
+                    elif i == 2:
+                        timeout_check_interval = float(PID_vars_new[i])
+                        if isinstance(timeout_check_interval, timedelta):
+                            timeout_check_interval_s = (
+                                timeout_check_interval.total_seconds()
+                            )
+                        else:
+                            timeout_check_interval_s = timeout_check_interval
+                            timeout_check_interval = timedelta(
+                                seconds=timeout_check_interval_s
+                            )
+                        logger.info(f"Updataed timeout_check_interval {change}")
+                    elif i == 3:
+                        watch_interval = float(PID_vars_new[i])
+                        controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
+                        logger.info(f"Updataed watch_interval {change}")
 
     except KeyboardInterrupt:
         controller.stop()

--- a/hpcflow/sdk/helper/helper.py
+++ b/hpcflow/sdk/helper/helper.py
@@ -80,7 +80,7 @@ def start_helper(
 ):
     PID_file = get_PID_file_path(app)
     if PID_file.is_file():
-        helper_pid=get_helper_PID(app)[0]
+        helper_pid = get_helper_PID(app)[0]
         print(f"Helper already running, with process ID: {helper_pid}")
 
     else:
@@ -147,8 +147,12 @@ def modify_helper(
 ):
     PID_file = get_PID_file_path(app)
     if PID_file.is_file():
-        [helper_pid,to,tci,wi]=strip_helper_PID(app)
-        if float(to) != timeout or float(tci) != timeout_check_interval or float(wi) != watch_interval :
+        [helper_pid, to, tci, wi] = strip_helper_PID(app)
+        if (
+            float(to) != timeout
+            or float(tci) != timeout_check_interval
+            or float(wi) != watch_interval
+        ):
             logger = get_helper_logger(app)
             logger.info(
                 f"Modifying helper with pid={helper_pid}"
@@ -202,8 +206,9 @@ def strip_helper_PID(app):
         with PID_file.open("rt") as fp:
             pidlines = fp.readlines()
             for i in range(4):
-                pidlines[i]=pidlines[i].strip('pid =tmeou-chknrvalw\n')
+                pidlines[i] = pidlines[i].strip("pid =tmeou-chknrvalw\n")
         return pidlines
+
 
 def get_helper_PID(app):
 
@@ -213,7 +218,7 @@ def get_helper_PID(app):
         return None
     else:
         with PID_file.open("rt") as fp:
-            helper_pid = int(fp.readline().strip('pid =\n'))
+            helper_pid = int(fp.readline().strip("pid =\n"))
         return helper_pid, PID_file
 
 
@@ -323,12 +328,12 @@ def run_helper(
             time_left_s = (end_time - datetime.now()).total_seconds()
             if time_left_s <= 0:
                 helper_timeout(app, timeout, controller, logger)
-            time.sleep(min(timeout_check_interval_s,time_left_s))
-            #Reading args from PID file
+            time.sleep(min(timeout_check_interval_s, time_left_s))
+            # Reading args from PID file
             PID_vars_new = strip_helper_PID(app)
-            for i in [1,2,3]:
+            for i in [1, 2, 3]:
                 if PID_vars_new[i] != PID_vars[i]:
-                    change=f"parameter from {PID_vars[i]} to {PID_vars_new[i]}."
+                    change = f"parameter from {PID_vars[i]} to {PID_vars_new[i]}."
                     PID_vars[i] = PID_vars_new[i]
                     match i:
                         case 1:
@@ -343,13 +348,17 @@ def run_helper(
                         case 2:
                             timeout_check_interval = float(PID_vars_new[i])
                             if isinstance(timeout_check_interval, timedelta):
-                                timeout_check_interval_s = timeout_check_interval.total_seconds()
+                                timeout_check_interval_s = (
+                                    timeout_check_interval.total_seconds()
+                                )
                             else:
                                 timeout_check_interval_s = timeout_check_interval
-                                timeout_check_interval = timedelta(seconds=timeout_check_interval_s)
+                                timeout_check_interval = timedelta(
+                                    seconds=timeout_check_interval_s
+                                )
                             logger.info(f"Updataed timeout_check_interval {change}")
                         case 3:
-                            watch_interval=float(PID_vars_new[i])
+                            watch_interval = float(PID_vars_new[i])
                             # controller = MonitorController(get_watcher_file_path(app), watch_interval, logger)
                             logger.info(f"Updataed watch_interval {change}")
                             # Would this work?

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -39,6 +39,8 @@ def test_modify_helper(app):
     assert args["watch_interval"] == 1
     time.sleep(1.5)
 
+    helper.get_helper_uptime(app)
+
     helper.modify_helper(app, timeout=5, timeout_check_interval=2, watch_interval=1)
     time.sleep(3.5)
     # If the parameters have been loaded correctly, then it should have timed out by now.

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -53,12 +53,11 @@ def test_modify_helper(app):
         assert False
 
     # This checks the logs were updated correctly and without repetition.
-    logfile_h = helper.get_helper_log_path(app)
-    logfile_r = helper.get_user_data_dir(app) / "helper_run.log"
+    logfile = helper.get_helper_log_path(app)
     mod_count = 0
     update_count = 0
     timeout = 0
-    with open(logfile_h, "r") as lf:
+    with open(logfile, "r") as lf:
         for line in lf:
             if " - INFO - " in line:
                 (t, m) = line.split(" - INFO - ")
@@ -70,21 +69,9 @@ def test_modify_helper(app):
                         update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
                         timeout = timeout + 1
-    with open(logfile_r, "r") as lf:
-        for line in lf:
-            if " - INFO - " in line:
-                (t, m) = line.split(" - INFO - ")
-                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
-                if logt > tstart:
-                    if "Modifying" in m:
-                        mod_count = mod_count + 1
-                    elif "Updated" in m:
-                        update_count = update_count + 1
-                    elif "Helper exiting due to timeout" in m:
-                        timeout = timeout + 1
-    assert timeout == 2
-    assert update_count == 6
-    assert mod_count == 4
+    assert timeout == 1
+    assert update_count == 3
+    assert mod_count == 2
 
 
 def test_modify_helper_cli(app):
@@ -125,24 +112,11 @@ def test_modify_helper_cli(app):
     so = cli(r, args="helper pid")
     assert so == "Helper not running!"
 
-    logfile_h = cli(r, args="helper log-path")
-    logfile_r = logfile_h[:-4] + "_run.log"
+    logfile = cli(r, args="helper log-path")
     mod_count = 0
     update_count = 0
     timeout = 0
-    with open(logfile_h, "r") as lf:
-        for line in lf:
-            if " - INFO - " in line:
-                (t, m) = line.split(" - INFO - ")
-                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
-                if logt > tstart:
-                    if "Modifying" in m:
-                        mod_count = mod_count + 1
-                    elif "Updated" in m:
-                        update_count = update_count + 1
-                    elif "Helper exiting due to timeout" in m:
-                        timeout = timeout + 1
-    with open(logfile_r, "r") as lf:
+    with open(logfile, "r") as lf:
         for line in lf:
             if " - INFO - " in line:
                 (t, m) = line.split(" - INFO - ")

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -39,8 +39,6 @@ def test_modify_helper(app):
     assert args["watch_interval"] == 1
     time.sleep(1.5)
 
-    helper.get_helper_uptime(app)
-
     helper.modify_helper(app, timeout=5, timeout_check_interval=2, watch_interval=1)
     time.sleep(3.5)
     # If the parameters have been loaded correctly, then it should have timed out by now.
@@ -49,6 +47,7 @@ def test_modify_helper(app):
         assert True
     else:
         helper.get_helper_uptime(app)
+        stop_helper(app)
         assert False
 
     # This checks the logs were updated correctly and without repetition.
@@ -70,7 +69,7 @@ def test_modify_helper(app):
                         timeout = 1
     assert timeout == 1
     assert update_count == 3
-    assert mod_count == 3
+    assert mod_count == 2
 
 
 def test_modify_helper_cli(app):

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -40,7 +40,7 @@ def test_modify_helper(app):
     time.sleep(1.5)
 
     helper.modify_helper(app, timeout=5, timeout_check_interval=2, watch_interval=1)
-    time.sleep(3.5)
+    time.sleep(10)
     # If the parameters have been loaded correctly, then it should have timed out by now.
     pid = helper.get_helper_PID(app)
     if pid == None:

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -25,11 +25,12 @@ def test_modify_helper(app):
     time.sleep(2.5)
 
     # This checks that parameters already in the file are being compared to new inputs
+    pytest_stdout = sys.stdout
     so = io.StringIO()  # Create StringIO object
     sys.stdout = so  # Redirect stdout.
     helper.modify_helper(app, timeout=60, timeout_check_interval=1, watch_interval=3)
     assert so.getvalue().splitlines()[-1] == "Helper parameters already met."
-    sys.stdout = sys.__stdout__  # Reset stdout.
+    sys.stdout = pytest_stdout  # Reset stdout.
 
     helper.modify_helper(app, timeout=60, timeout_check_interval=2, watch_interval=1)
     # This checks if the file was written with new variables
@@ -94,7 +95,7 @@ def test_modify_helper_cli(app):
         r, args="helper start --timeout 60 --timeout-check-interval 1 --watch-interval 3"
     )
     assert so == ""
-    time.sleep(0.5)
+    time.sleep(2.5)
     so = cli(
         args="helper modify --timeout 60 --timeout-check-interval 1 --watch-interval 3"
     )
@@ -104,23 +105,23 @@ def test_modify_helper_cli(app):
         r, args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1"
     )
     assert so == ""
-    time.sleep(1.5)
+    time.sleep(3.5)
     so = cli(
         r, args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1"
     )
     assert so == "Helper parameters already met."
 
     so = cli(
-        r, args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1"
+        r, args="helper modify --timeout 10 --timeout-check-interval 2 --watch-interval 1"
     )
     assert so == ""
-    time.sleep(2.5)
+    time.sleep(3)
     so = cli(
         r, args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1"
     )
     assert so == "Helper parameters already met."
 
-    time.sleep(1)
+    time.sleep(5)
     so = cli(r, args="helper pid")
     assert so == "Helper not running!"
 

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -1,0 +1,122 @@
+import pytest
+from datetime import datetime, timedelta
+import time
+
+import io
+import sys
+
+from click.testing import CliRunner
+
+from hpcflow.sdk.helper import helper
+from tempfile import gettempdir
+from hpcflow.api import hpcflow, load_config
+
+
+
+@pytest.fixture
+def app():
+    load_config(config_dir=gettempdir())
+    return hpcflow
+
+
+def test_modify_helper(app):
+    tstart = datetime.now()- timedelta(seconds=0.2)
+
+    helper.start_helper(app,timeout = 60, timeout_check_interval = 1, watch_interval = 3)
+    time.sleep(.5)
+
+    # This checks that parameters already in the file are being compared to new inputs
+    so = io.StringIO()              # Create StringIO object
+    sys.stdout = so                 # Redirect stdout.
+    helper.modify_helper(app,timeout = 60, timeout_check_interval = 1, watch_interval = 3)
+    assert so.getvalue().splitlines()[-1] == "Helper parameters already met."
+    sys.stdout = sys.__stdout__     # Reset stdout.
+
+    helper.modify_helper(app,timeout = 60, timeout_check_interval = 2, watch_interval = 1)
+    # This checks if the file was written with new variables
+    args=helper.read_helper_args(app)
+    assert args['timeout'] == 60
+    assert args['timeout_check_interval'] == 2
+    assert args['watch_interval'] == 1
+    time.sleep(1.5)
+
+    helper.modify_helper(app,timeout = 5, timeout_check_interval = 2, watch_interval = 1)
+    time.sleep(3.5)
+    # If the parameters have been loaded correctly, then it should have timed out by now.
+    pid = helper.get_helper_PID(app)
+    assert pid == None
+
+    # This checks the logs were updated correctly and without repetition.
+    logfile=helper.get_helper_log_path(app)
+    mod_count = 0
+    update_count = 0
+    timeout = 0
+    with open(logfile,"r") as lf:
+        for line in lf:
+            if " - INFO - " in line:
+                (t, m) = line.split(" - INFO - ")
+                logt=datetime.strptime(t[0:22],'%Y-%m-%d %H:%M:%S,%f')
+                if logt > tstart:
+                    if "Modifying" in m:
+                        mod_count = mod_count+1
+                    elif "Updated" in m:
+                        update_count = update_count+1
+                    elif "Helper exiting due to timeout" in m:
+                        timeout = 1
+    assert timeout == 1
+    assert update_count == 3
+    assert mod_count == 2
+
+
+def test_modify_helper_cli(app):
+    tstart = datetime.now()- timedelta(seconds=0.2)
+    r = CliRunner()    
+
+    so=cli(r,args="helper start --timeout 60 --timeout-check-interval 1 --watch-interval 3")
+    assert so == ""
+    time.sleep(.5)
+    so=cli(args="helper modify --timeout 60 --timeout-check-interval 1 --watch-interval 3")
+    assert so == "Helper parameters already met."
+    
+    so=cli(r,args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1")
+    assert so == ""
+    time.sleep(1.5)
+    so=cli(r,args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1")
+    assert so == "Helper parameters already met."
+
+    so=cli(r,args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1")
+    assert so == ""
+    time.sleep(2.5)
+    so=cli(r,args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1")
+    assert so == "Helper parameters already met."
+
+    time.sleep(1)
+    so=cli(r,args="helper pid")
+    assert so == "Helper not running!"
+
+    logfile=cli(r=r,args="helper log-path")
+    mod_count = 0
+    update_count = 0
+    timeout = 0
+    with open(logfile,"r") as lf:
+        for line in lf:
+            if " - INFO - " in line:
+                (t, m) = line.split(" - INFO - ")
+                logt=datetime.strptime(t[0:22],'%Y-%m-%d %H:%M:%S,%f')
+                if logt > tstart:
+                    if "Modifying" in m:
+                        mod_count = mod_count+1
+                    elif "Updated" in m:
+                        update_count = update_count+1
+                    elif "Helper exiting due to timeout" in m:
+                        timeout = 1
+    assert timeout == 1
+    assert update_count == 3
+    assert mod_count == 2
+
+
+
+    
+def cli(r=CliRunner(), args=""):
+    so=r.invoke(hpcflow.CLI , args)
+    return so.output.strip()

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -18,6 +18,7 @@ def app():
     return hpcflow
 
 
+@pytest.mark.skip(reason=("Testing cli test on CentOS."))
 def test_modify_helper(app):
     tstart = datetime.now() - timedelta(seconds=0.2)
 

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -44,13 +44,7 @@ def test_modify_helper(app):
     time.sleep(5)
     # If the parameters have been loaded correctly, then it should have timed out by now.
     pid = helper.get_helper_PID(app)
-    if pid == None:
-        helper.get_helper_uptime(app)
-        assert True
-    else:
-        helper.get_helper_uptime(app)
-        helper.stop_helper(app)
-        assert False
+    assert pid == None
 
     # This checks the logs were updated correctly and without repetition.
     logfile = helper.get_helper_log_path(app)

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -22,7 +22,7 @@ def test_modify_helper(app):
     tstart = datetime.now() - timedelta(seconds=0.2)
 
     helper.start_helper(app, timeout=60, timeout_check_interval=1, watch_interval=3)
-    time.sleep(0.5)
+    time.sleep(2.5)
 
     # This checks that parameters already in the file are being compared to new inputs
     so = io.StringIO()  # Create StringIO object

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -44,6 +44,7 @@ def test_modify_helper(app):
     # If the parameters have been loaded correctly, then it should have timed out by now.
     pid = helper.get_helper_PID(app)
     if pid == None:
+        helper.get_helper_uptime(app)
         assert True
     else:
         helper.get_helper_uptime(app)

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -18,7 +18,6 @@ def app():
     return hpcflow
 
 
-@pytest.mark.skip(reason=("Testing cli test on CentOS."))
 def test_modify_helper(app):
     tstart = datetime.now() - timedelta(seconds=0.2)
 
@@ -69,7 +68,7 @@ def test_modify_helper(app):
                         timeout = 1
     assert timeout == 1
     assert update_count == 3
-    assert mod_count == 2
+    assert mod_count == 3
 
 
 def test_modify_helper_cli(app):

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -37,7 +37,7 @@ def test_modify_helper(app):
     assert args["timeout"] == 60
     assert args["timeout_check_interval"] == 2
     assert args["watch_interval"] == 1
-    time.sleep(1.5)
+    time.sleep(3.5)
 
     helper.modify_helper(app, timeout=5, timeout_check_interval=2, watch_interval=1)
     time.sleep(5)

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -43,7 +43,11 @@ def test_modify_helper(app):
     time.sleep(3.5)
     # If the parameters have been loaded correctly, then it should have timed out by now.
     pid = helper.get_helper_PID(app)
-    assert pid == None
+    if pid == None:
+        assert True
+    else:
+        helper.get_helper_uptime(app)
+        assert False
 
     # This checks the logs were updated correctly and without repetition.
     logfile = helper.get_helper_log_path(app)
@@ -64,7 +68,7 @@ def test_modify_helper(app):
                         timeout = 1
     assert timeout == 1
     assert update_count == 3
-    assert mod_count == 3
+    assert mod_count == 2
 
 
 def test_modify_helper_cli(app):

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -68,21 +68,21 @@ def test_modify_helper(app):
                     elif "Updated" in m:
                         update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
-                        timeout = 1
-    # with open(logfile_r, "r") as lf:
-    #     for line in lf:
-    #         if " - INFO - " in line:
-    #             (t, m) = line.split(" - INFO - ")
-    #             logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
-    #             if logt > tstart:
-    #                 if "Modifying" in m:
-    #                     mod_count = mod_count + 1
-    #                 elif "Updated" in m:
-    #                     update_count = update_count + 1
-    #                 elif "Helper exiting due to timeout" in m:
-    #                     timeout = 1
-    assert timeout == 1
-    assert update_count == 3
+                        timeout = timeout + 1
+    with open(logfile_r, "r") as lf:
+        for line in lf:
+            if " - INFO - " in line:
+                (t, m) = line.split(" - INFO - ")
+                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
+                if logt > tstart:
+                    if "Modifying" in m:
+                        mod_count = mod_count + 1
+                    elif "Updated" in m:
+                        update_count = update_count + 1
+                    elif "Helper exiting due to timeout" in m:
+                        timeout = timeout + 1
+    assert timeout == 2
+    assert update_count == 6
     assert mod_count == 4
 
 
@@ -124,11 +124,12 @@ def test_modify_helper_cli(app):
     so = cli(r, args="helper pid")
     assert so == "Helper not running!"
 
-    logfile = cli(r=r, args="helper log-path")
+    logfile_h = cli(r, args="helper log-path")
+    logfile_r = logfile_h[:-4] + "_run.log"
     mod_count = 0
     update_count = 0
     timeout = 0
-    with open(logfile, "r") as lf:
+    with open(logfile_h, "r") as lf:
         for line in lf:
             if " - INFO - " in line:
                 (t, m) = line.split(" - INFO - ")
@@ -139,7 +140,19 @@ def test_modify_helper_cli(app):
                     elif "Updated" in m:
                         update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
-                        timeout = 1
+                        timeout = timeout + 1
+    with open(logfile_r, "r") as lf:
+        for line in lf:
+            if " - INFO - " in line:
+                (t, m) = line.split(" - INFO - ")
+                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
+                if logt > tstart:
+                    if "Modifying" in m:
+                        mod_count = mod_count + 1
+                    elif "Updated" in m:
+                        update_count = update_count + 1
+                    elif "Helper exiting due to timeout" in m:
+                        timeout = timeout + 1
     assert timeout == 1
     assert update_count == 3
     assert mod_count == 2

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -12,7 +12,6 @@ from tempfile import gettempdir
 from hpcflow.api import hpcflow, load_config
 
 
-
 @pytest.fixture
 def app():
     load_config(config_dir=gettempdir())
@@ -20,47 +19,47 @@ def app():
 
 
 def test_modify_helper(app):
-    tstart = datetime.now()- timedelta(seconds=0.2)
+    tstart = datetime.now() - timedelta(seconds=0.2)
 
-    helper.start_helper(app,timeout = 60, timeout_check_interval = 1, watch_interval = 3)
-    time.sleep(.5)
+    helper.start_helper(app, timeout=60, timeout_check_interval=1, watch_interval=3)
+    time.sleep(0.5)
 
     # This checks that parameters already in the file are being compared to new inputs
-    so = io.StringIO()              # Create StringIO object
-    sys.stdout = so                 # Redirect stdout.
-    helper.modify_helper(app,timeout = 60, timeout_check_interval = 1, watch_interval = 3)
+    so = io.StringIO()  # Create StringIO object
+    sys.stdout = so  # Redirect stdout.
+    helper.modify_helper(app, timeout=60, timeout_check_interval=1, watch_interval=3)
     assert so.getvalue().splitlines()[-1] == "Helper parameters already met."
-    sys.stdout = sys.__stdout__     # Reset stdout.
+    sys.stdout = sys.__stdout__  # Reset stdout.
 
-    helper.modify_helper(app,timeout = 60, timeout_check_interval = 2, watch_interval = 1)
+    helper.modify_helper(app, timeout=60, timeout_check_interval=2, watch_interval=1)
     # This checks if the file was written with new variables
-    args=helper.read_helper_args(app)
-    assert args['timeout'] == 60
-    assert args['timeout_check_interval'] == 2
-    assert args['watch_interval'] == 1
+    args = helper.read_helper_args(app)
+    assert args["timeout"] == 60
+    assert args["timeout_check_interval"] == 2
+    assert args["watch_interval"] == 1
     time.sleep(1.5)
 
-    helper.modify_helper(app,timeout = 5, timeout_check_interval = 2, watch_interval = 1)
+    helper.modify_helper(app, timeout=5, timeout_check_interval=2, watch_interval=1)
     time.sleep(3.5)
     # If the parameters have been loaded correctly, then it should have timed out by now.
     pid = helper.get_helper_PID(app)
     assert pid == None
 
     # This checks the logs were updated correctly and without repetition.
-    logfile=helper.get_helper_log_path(app)
+    logfile = helper.get_helper_log_path(app)
     mod_count = 0
     update_count = 0
     timeout = 0
-    with open(logfile,"r") as lf:
+    with open(logfile, "r") as lf:
         for line in lf:
             if " - INFO - " in line:
                 (t, m) = line.split(" - INFO - ")
-                logt=datetime.strptime(t[0:22],'%Y-%m-%d %H:%M:%S,%f')
+                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
                 if logt > tstart:
                     if "Modifying" in m:
-                        mod_count = mod_count+1
+                        mod_count = mod_count + 1
                     elif "Updated" in m:
-                        update_count = update_count+1
+                        update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
                         timeout = 1
     assert timeout == 1
@@ -69,45 +68,57 @@ def test_modify_helper(app):
 
 
 def test_modify_helper_cli(app):
-    tstart = datetime.now()- timedelta(seconds=0.2)
-    r = CliRunner()    
+    tstart = datetime.now() - timedelta(seconds=0.2)
+    r = CliRunner()
 
-    so=cli(r,args="helper start --timeout 60 --timeout-check-interval 1 --watch-interval 3")
+    so = cli(
+        r, args="helper start --timeout 60 --timeout-check-interval 1 --watch-interval 3"
+    )
     assert so == ""
-    time.sleep(.5)
-    so=cli(args="helper modify --timeout 60 --timeout-check-interval 1 --watch-interval 3")
+    time.sleep(0.5)
+    so = cli(
+        args="helper modify --timeout 60 --timeout-check-interval 1 --watch-interval 3"
+    )
     assert so == "Helper parameters already met."
-    
-    so=cli(r,args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1")
+
+    so = cli(
+        r, args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1"
+    )
     assert so == ""
     time.sleep(1.5)
-    so=cli(r,args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1")
+    so = cli(
+        r, args="helper modify --timeout 60 --timeout-check-interval 2 --watch-interval 1"
+    )
     assert so == "Helper parameters already met."
 
-    so=cli(r,args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1")
+    so = cli(
+        r, args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1"
+    )
     assert so == ""
     time.sleep(2.5)
-    so=cli(r,args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1")
+    so = cli(
+        r, args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1"
+    )
     assert so == "Helper parameters already met."
 
     time.sleep(1)
-    so=cli(r,args="helper pid")
+    so = cli(r, args="helper pid")
     assert so == "Helper not running!"
 
-    logfile=cli(r=r,args="helper log-path")
+    logfile = cli(r=r, args="helper log-path")
     mod_count = 0
     update_count = 0
     timeout = 0
-    with open(logfile,"r") as lf:
+    with open(logfile, "r") as lf:
         for line in lf:
             if " - INFO - " in line:
                 (t, m) = line.split(" - INFO - ")
-                logt=datetime.strptime(t[0:22],'%Y-%m-%d %H:%M:%S,%f')
+                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
                 if logt > tstart:
                     if "Modifying" in m:
-                        mod_count = mod_count+1
+                        mod_count = mod_count + 1
                     elif "Updated" in m:
-                        update_count = update_count+1
+                        update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
                         timeout = 1
     assert timeout == 1
@@ -115,8 +126,6 @@ def test_modify_helper_cli(app):
     assert mod_count == 2
 
 
-
-    
 def cli(r=CliRunner(), args=""):
-    so=r.invoke(hpcflow.CLI , args)
+    so = r.invoke(hpcflow.CLI, args)
     return so.output.strip()

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -117,7 +117,7 @@ def test_modify_helper_cli(app):
     assert so == ""
     time.sleep(3)
     so = cli(
-        r, args="helper modify --timeout 5 --timeout-check-interval 2 --watch-interval 1"
+        r, args="helper modify --timeout 10 --timeout-check-interval 2 --watch-interval 1"
     )
     assert so == "Helper parameters already met."
 

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -69,18 +69,18 @@ def test_modify_helper(app):
                         update_count = update_count + 1
                     elif "Helper exiting due to timeout" in m:
                         timeout = 1
-    with open(logfile_r, "r") as lf:
-        for line in lf:
-            if " - INFO - " in line:
-                (t, m) = line.split(" - INFO - ")
-                logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
-                if logt > tstart:
-                    if "Modifying" in m:
-                        mod_count = mod_count + 1
-                    elif "Updated" in m:
-                        update_count = update_count + 1
-                    elif "Helper exiting due to timeout" in m:
-                        timeout = 1
+    # with open(logfile_r, "r") as lf:
+    #     for line in lf:
+    #         if " - INFO - " in line:
+    #             (t, m) = line.split(" - INFO - ")
+    #             logt = datetime.strptime(t[0:22], "%Y-%m-%d %H:%M:%S,%f")
+    #             if logt > tstart:
+    #                 if "Modifying" in m:
+    #                     mod_count = mod_count + 1
+    #                 elif "Updated" in m:
+    #                     update_count = update_count + 1
+    #                 elif "Helper exiting due to timeout" in m:
+    #                     timeout = 1
     assert timeout == 1
     assert update_count == 3
     assert mod_count == 2

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -83,7 +83,7 @@ def test_modify_helper(app):
     #                     timeout = 1
     assert timeout == 1
     assert update_count == 3
-    assert mod_count == 2
+    assert mod_count == 4
 
 
 def test_modify_helper_cli(app):

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -47,7 +47,7 @@ def test_modify_helper(app):
         assert True
     else:
         helper.get_helper_uptime(app)
-        stop_helper(app)
+        helper.stop_helper(app)
         assert False
 
     # This checks the logs were updated correctly and without repetition.

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -64,7 +64,7 @@ def test_modify_helper(app):
                         timeout = 1
     assert timeout == 1
     assert update_count == 3
-    assert mod_count == 2
+    assert mod_count == 3
 
 
 def test_modify_helper_cli(app):


### PR DESCRIPTION
Added `modify` command to helper, which allows changes to timeout, check interval and watch interval. The variables are written into the PID file, and read every check_interval.

Also improved the way the timeout limit was implemented, to be able to handle check intervals greater than the timeout, and always run for the whole span of timeout, as opposed to timeout-check_interval.

Resolves issue #290 