### PR TITLE
feat: test kill_proc_tree

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,28 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
+
+  test-CentOS:
+    runs-on: ubuntu-latest
+    container:
+      image: aplowman/centos7-poetry
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Configure poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Cache the virtualenv
+        uses: actions/cache@v3
+        with:
+          path: ./.venv
+          key: venv-CentOS-test-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --without dev,pyinstaller
+
+      - name: Run tests
+        run: |
+          poetry run python3 -m pytest hpcflow/tests/unit/test_helper.py -k 'kill_proc' --verbose --exitfirst -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,4 +120,4 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run python -m pytest --verbose --exitfirst
+          poetry run python -m pytest --verbose --exitfirst -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,59 @@ on:
     branches: [main, develop] # have to manually change these
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # PAT of user who has permission to bypass branch
+          # protection || or standard GITHUB_TOKEN if running on an external fork (won't
+          # be able to commit fixes):
+          token: ${{ secrets.HPCFLOW_ACTIONS_TOKEN || secrets.GITHUB_TOKEN }}
+          # checkout PR source branch (head_ref) if event is pull_request:
+          ref: ${{ github.head_ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - run: |
+          git config user.name hpcflow-actions
+          git config user.email hpcflow-actions@users.noreply.github.com
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION_PRE_COMMIT }}
+
+      - name: pre-commit
+        # avoid exit code 1 (which halts GH actions) from pre-commit run command by
+        # running twice:
+        run: |
+          pip install pre-commit
+          pre-commit install
+          export SKIP=no-commit-to-branch
+          pre-commit run --all-files || pre-commit run --all-files
+
+      - name: pre-commit push changes
+        run: |
+          if git diff --quiet; then
+            echo "No pre-commit changes"
+          else
+            git commit -am "pre-commit fixes [skip ci]"
+            git push
+          fi
+
   test:
+    needs: pre-commit
     strategy:
       fail-fast: false
       matrix:
         python-version:
           - "3.7"
-          # - "3.8"
-          # - "3.9"
-          # - "3.10"
+          - "3.8"
+          - "3.9"
+          - "3.10"
         os:
-          # - ubuntu-latest
+          - ubuntu-latest
           - macos-latest
-          # - windows-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,9 +97,10 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run python3 -m pytest hpcflow/tests/unit/test_helper.py -k 'kill_proc' --verbose --exitfirst -s
+          poetry run python -m pytest --verbose --exitfirst
 
   test-CentOS:
+    needs: pre-commit
     runs-on: ubuntu-latest
     container:
       image: aplowman/centos7-poetry
@@ -82,4 +123,4 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run python3 -m pytest hpcflow/tests/unit/test_helper.py -k 'kill_proc' --verbose --exitfirst -s
+          poetry run python -m pytest --verbose --exitfirst -k "not test_kill_proc_tree"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,59 +13,19 @@ on:
     branches: [main, develop] # have to manually change these
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # PAT of user who has permission to bypass branch
-          # protection || or standard GITHUB_TOKEN if running on an external fork (won't
-          # be able to commit fixes):
-          token: ${{ secrets.HPCFLOW_ACTIONS_TOKEN || secrets.GITHUB_TOKEN }}
-          # checkout PR source branch (head_ref) if event is pull_request:
-          ref: ${{ github.head_ref || github.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - run: |
-          git config user.name hpcflow-actions
-          git config user.email hpcflow-actions@users.noreply.github.com
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION_PRE_COMMIT }}
-
-      - name: pre-commit
-        # avoid exit code 1 (which halts GH actions) from pre-commit run command by
-        # running twice:
-        run: |
-          pip install pre-commit
-          pre-commit install
-          export SKIP=no-commit-to-branch
-          pre-commit run --all-files || pre-commit run --all-files
-
-      - name: pre-commit push changes
-        run: |
-          if git diff --quiet; then
-            echo "No pre-commit changes"
-          else
-            git commit -am "pre-commit fixes [skip ci]"
-            git push
-          fi
-
   test:
-    needs: pre-commit
     strategy:
       fail-fast: false
       matrix:
         python-version:
           - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          # - "3.8"
+          # - "3.9"
+          # - "3.10"
         os:
-          - ubuntu-latest
+          # - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -92,32 +52,5 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
 
-      - name: Run tests
-        run: |
-          poetry run python -m pytest --verbose --exitfirst
-
-  test-CentOS:
-    needs: pre-commit
-    runs-on: ubuntu-latest
-    container:
-      image: aplowman/centos7-poetry
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-
-      - name: Cache the virtualenv
-        uses: actions/cache@v3
-        with:
-          path: ./.venv
-          key: venv-CentOS-test-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        run: poetry install --without dev,pyinstaller
-
-      - name: Run tests
-        run: |
-          poetry run python -m pytest --verbose --exitfirst -s
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,12 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+
+      - name: Run tests
+        run: |
+          poetry run python3 -m pytest hpcflow/tests/unit/test_helper.py -k 'kill_proc' --verbose --exitfirst -s
 
   test-CentOS:
     runs-on: ubuntu-latest

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -128,15 +128,18 @@ def test_kill_proc_tree():
     pytest_stdout = sys.stdout
     sys.stdout = sys.__stdout__
     # fhadb/\
+    print(f"\nfhadb:--------------------------------------------------------------")
+    print(f"fhadb: creating queue")
     queue = Queue()
     depth = 3
+    print(f"fhadb: creating parent")
     parent = Process(
         target=sleeping_child,
         args=[queue, 10, depth],
     )
+    print(f"fhadb: starting parent")
     parent.start()
-    print(f"\nfhadb:--------------------------------------------------------------")
-    print(f"\nfhadb: parent:{parent.pid}")
+    print(f"fhadb: parent:{parent.pid}")
     children = []
     fhadbslept = datetime.now()
     while len(children) < depth:

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -124,6 +124,10 @@ def test_clear_helper_no_process(app):
 
 
 def test_kill_proc_tree():
+    # fhadb\/
+    pytest_stdout = sys.stdout
+    sys.stdout = sys.__stdout__
+    # fhadb/\
     queue = Queue()
     depth = 3
     parent = Process(
@@ -142,19 +146,28 @@ def test_kill_proc_tree():
     children.append(parent.pid)
     print(f"fhadb: pids:{children}")
     try:
+        print(f"fhadb: about to call kill proc tree")
         g, a = helper.kill_proc_tree(parent.pid)
+        print(f"fhadb: asserting")
         assert len(g) == depth + 1
         assert len(a) == 0
     finally:
+        print(f"fhadb: in finally")
         sitll_running = 0
         for pid in children:
+            print(f"fhadb: in for, pid={pid}")
             try:
                 proc = psutil.Process(pid)
                 print(f"Process {proc.pid} still running!")
                 sitll_running = sitll_running + 1
             except psutil.NoSuchProcess:
+                print(f"fhadb: in except, pid={pid}")
                 pass
+        print(f"fhadb: asserting in finally")
         assert sitll_running == 0, "Some processes were not killed"
+        # fhadb\/
+        sys.stdout = pytest_stdout
+        # fhadb/\
 
 
 def test_get_helper_uptime(app):

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -123,6 +123,9 @@ def test_clear_helper_no_process(app):
     assert pid_fp.is_file() == False
 
 
+# This test does not pass on macOs with python 3.7... does not even print first output:
+## Fatal Python error: Illegal instruction
+### potentially related to security.. multithreading restriction
 def test_kill_proc_tree():
     # fhadb\/
     pytest_stdout = sys.stdout

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -129,8 +129,15 @@ def test_clear_helper_no_process(app):
 ## fhadb: creating queue
 ## fhadb: creating parent
 ## fhadb: starting parent
-## fhadb: parent:3725
+## fhadb: parent:3530
+## fhadb: initializing slept
+## fhadb: receiving pids from queue
+## fhadb:  in sleeping child. depth: 3
+## fhadb:   depth > 1
+## fhadb:   starting child
 ## Fatal Python error: Illegal instruction
+## Current thread 0x00000001083ee600 (most recent call first):
+##   File "/Users/runner/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/multiprocessing/popen_fork.py", line 70 in _launch
 ### no longer think its related to security...
 def test_kill_proc_tree():
     # fhadb\/

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -130,10 +130,12 @@ def test_kill_proc_tree():
         args=[10, depth],
     )
     parent.start()
-    time.sleep(0.2)
+    print(f"\nfhadb: parent:{parent.pid}")
+    time.sleep(2)
     children = psutil.Process(parent.pid).children(recursive=True)
     children.append(parent)
     pids = [child.pid for child in children]
+    print(f"fhadb: pids:{pids}")
     try:
         g, a = helper.kill_proc_tree(parent.pid)
         assert len(g) == depth + 1
@@ -496,4 +498,5 @@ def sleeping_child(t, depth):
     else:
         child = Process(target=time.sleep, args=[t])
     child.start()
+    print(f"fhadb:   child {depth}:{child.pid}")
     child.join()

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -123,9 +123,15 @@ def test_clear_helper_no_process(app):
     assert pid_fp.is_file() == False
 
 
-# This test does not pass on macOs with python 3.7... does not even print first output:
+# This test does not pass on macOs with python 3.7... inside tmate it gets here:
+## hpcflow/tests/unit/test_helper.py::test_kill_proc_tree
+## fhadb:--------------------------------------------------------------
+## fhadb: creating queue
+## fhadb: creating parent
+## fhadb: starting parent
+## fhadb: parent:3725
 ## Fatal Python error: Illegal instruction
-### potentially related to security.. multithreading restriction
+### no longer think its related to security...
 def test_kill_proc_tree():
     # fhadb\/
     pytest_stdout = sys.stdout
@@ -144,7 +150,9 @@ def test_kill_proc_tree():
     parent.start()
     print(f"fhadb: parent:{parent.pid}")
     children = []
+    print(f"fhadb: initializing slept")
     fhadbslept = datetime.now()
+    print(f"fhadb: receiving pids from queue")
     while len(children) < depth:
         children.append(queue.get())
         print(f"fhadb: received one... qpids:{children}")
@@ -517,11 +525,16 @@ def test_modify_helper(app):
 
 
 def sleeping_child(queue, t, depth):
+    print(f"fhadb:  in sleeping child. depth: {depth}")
     if depth > 1:
+        print(f"fhadb:   depth > 1")
         child = Process(target=sleeping_child, args=[queue, t, depth - 1])
     else:
+        print(f"fhadb:   depth <= 1")
         child = Process(target=time.sleep, args=[t])
+    print(f"fhadb:   starting child")
     child.start()
+    print(f"fhadb:   sending child pid to queue")
     queue.put(child.pid)
     print(f"fhadb:   child {depth}:{child.pid}")
     child.join()

--- a/hpcflow/tests/unit/test_helper.py
+++ b/hpcflow/tests/unit/test_helper.py
@@ -131,15 +131,14 @@ def test_kill_proc_tree():
         args=[queue, 10, depth],
     )
     parent.start()
+    print(f"\nfhadb:--------------------------------------------------------------")
     print(f"\nfhadb: parent:{parent.pid}")
     children = []
-    fhadbslept = 0
+    fhadbslept = datetime.now()
     while len(children) < depth:
         children.append(queue.get())
-        time.sleep(0.01)
-        fhadbslept = fhadbslept + 0.01
-    print(f"fhadb: qpids:{children}")
-    print(f"fhadb: slept:{fhadbslept}")
+        print(f"fhadb: received one... qpids:{children}")
+    print(f"fhadb: slept:{datetime.now()-fhadbslept}")
     children.append(parent.pid)
     print(f"fhadb: pids:{children}")
     try:


### PR DESCRIPTION
Adds a test for kill proc tree, which does not work for macos with python 3.7 or centos, potentially due to resources available in the github runner.