### PR TITLE
Fix/poetry-modern-installation-failure

### DIFF
--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -139,6 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
+      - name: Install poetry
+        run: python -m pip install poetry==1.4
+
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true

--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -139,13 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
-      - name: Install poetry
-        run: python -m pip install poetry==1.4
-
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
-          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -45,8 +45,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,8 +140,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -42,10 +42,11 @@ jobs:
           key: venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,6 +140,7 @@ jobs:
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -42,10 +42,11 @@ jobs:
           key: {% raw %}venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,6 +140,7 @@ jobs:
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -139,6 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
+      - name: Install poetry
+        run: python -m pip install poetry==1.4
+
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -139,13 +139,9 @@ jobs:
           # this is to fix GIT not liking owner of the checkout dir
           chown -R $(id -u):$(id -g) $PWD
 
-      - name: Install poetry
-        run: python -m pip install poetry==1.4
-
       - name: Configure poetry
         run: |
           poetry config virtualenvs.in-project true
-          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -45,8 +45,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -139,8 +140,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,8 +178,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -299,7 +300,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3
@@ -386,8 +389,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,10 +175,11 @@ jobs:
           key: venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -196,12 +197,12 @@ jobs:
       - name: Build with pyinstaller (Windows, file)
         if: contains(matrix.os, 'windows')
         working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO -BuildType 'onefile'
+        run: ./make.ps1 -ExeName 'hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}' -LogLevel INFO -BuildType 'onefile'
 
       - name: Build with pyinstaller (Windows, folder)
         if: contains(matrix.os, 'windows')
         working-directory: pyinstaller
-        run: ./make.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -LogLevel INFO -BuildType 'onedir'
+        run: ./make.ps1 -ExeName 'hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -LogLevel INFO -BuildType 'onedir'
 
       - name: Version check (windows, file)
         if: contains(matrix.os, 'windows')
@@ -262,7 +263,7 @@ jobs:
       - name: Compress folder (windows, folder)
         if: contains(matrix.os, 'windows')
         working-directory: pyinstaller
-        run: ./compress.ps1 -ExeName "hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -BuildType 'onedir'
+        run: ./compress.ps1 -ExeName 'hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -BuildType 'onedir'
 
       - name: Compress folder (non-windows, folder)
         if: "!contains(matrix.os, 'windows')" 
@@ -382,10 +383,11 @@ jobs:
           key: venv-release-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
@@ -490,10 +492,11 @@ jobs:
           key: venv-release-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without test,pyinstaller

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -178,8 +178,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -299,7 +300,9 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3
@@ -386,8 +389,9 @@ jobs:
         run: python -m pip install poetry==1.4
 
       - name: Configure poetry
-        run: poetry config virtualenvs.in-project true
-             poetry config installer.modern-installation false
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -175,10 +175,11 @@ jobs:
           key: {% raw %}venv-build-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -196,12 +197,12 @@ jobs:
       - name: Build with pyinstaller (Windows, file)
         if: contains(matrix.os, 'windows')
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}" -LogLevel INFO -BuildType 'onefile'{% endraw %}
+        run: ./make.ps1 -ExeName '{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}' -LogLevel INFO -BuildType 'onefile'{% endraw %}
 
       - name: Build with pyinstaller (Windows, folder)
         if: contains(matrix.os, 'windows')
         working-directory: {{ pyinstaller_dir }}
-        run: ./make.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -LogLevel INFO -BuildType 'onedir'{% endraw %}
+        run: ./make.ps1 -ExeName '{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -LogLevel INFO -BuildType 'onedir'{% endraw %}
 
       - name: Version check (windows, file)
         if: contains(matrix.os, 'windows')
@@ -262,7 +263,7 @@ jobs:
       - name: Compress folder (windows, folder)
         if: contains(matrix.os, 'windows')
         working-directory: {{ pyinstaller_dir }}
-        run: ./compress.ps1 -ExeName "{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir" -BuildType 'onedir'{% endraw %}
+        run: ./compress.ps1 -ExeName '{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -BuildType 'onedir'{% endraw %}
 
       - name: Compress folder (non-windows, folder)
         if: "!contains(matrix.os, 'windows')" 
@@ -382,10 +383,11 @@ jobs:
           key: {% raw %}venv-release-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: python -m pip install poetry==1.2.2
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
@@ -490,10 +492,11 @@ jobs:
           key: {% raw %}venv-release-${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}{% endraw %}
 
       - name: Install poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: python -m pip install poetry==1.4
 
       - name: Configure poetry
         run: poetry config virtualenvs.in-project true
+             poetry config installer.modern-installation false
 
       - name: Install dependencies
         run: poetry install --without test,pyinstaller

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,9 @@ jobs:
 
       - name: Install and configure poetry
         run: |
-          python -m pip install poetry
+          python -m pip install poetry==1.4
           poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -79,8 +79,9 @@ jobs:
 
       - name: Install and configure poetry
         run: |
-          python -m pip install poetry
+          python -m pip install poetry==1.4
           poetry config virtualenvs.in-project true
+          poetry config installer.modern-installation false
 
       - name: Cache the virtualenv
         uses: actions/cache@v3


### PR DESCRIPTION
Poetry v1.4 introduced a new default installation method. This currently doesn't work for hpcflow.

Have updated all actions installed poetry versions used to v1.4 and turned off the modern-installation method.

The only remaining outdated poetry version is used for building the pyinstaller executable on linux. Here we're using a centOS docker image that comes with poetry pre-installed.

This will be updated whenever the image is updated.