### PR TITLE
feat: Update ubuntu runners for build docs

### DIFF
--- a/.github/workflows/auto_add_to_board.yml
+++ b/.github/workflows/auto_add_to_board.yml
@@ -1,0 +1,14 @@
+name: Add issues to project board
+on: 
+  issues: 
+    types: 
+      - opened
+jobs: 
+  add-to-project: 
+    name: Add issue to project 
+    runs-on: ubuntu-latest 
+    steps: 
+      - uses: actions/add-to-project@v0.4.0 
+        with: 
+          github-token: ${{ secrets.HPCFLOW_PROJECT_ACTIONS_TOKEN }}
+          project-url: https://github.com/orgs/hpcflow/projects/7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,7 +450,7 @@ jobs:
 
   build-documentation:
     needs: release-github-PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -450,7 +450,7 @@ jobs:
 
   build-documentation:
     needs: release-github-PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Update Ubuntu runner for build documentation section of release workflow.

It used ububtu-18.04, which is no longer available.

Have updated to ubuntu-latest in line with the rest of the workflows.
