### PR TITLE
fix: always use importlib.resources method for running tests; otherwi…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    if: github.event.inputs.run_pre_commit == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_pre_commit == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -72,7 +72,7 @@ jobs:
 
   test:
     needs: pre-commit
-    if: github.event.inputs.run_unit_tests == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_unit_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +119,7 @@ jobs:
   test-CentOS:
     needs: pre-commit
     runs-on: ubuntu-latest
-    if: github.event.inputs.run_unit_tests == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_unit_tests == 'true'
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
@@ -153,7 +153,7 @@ jobs:
 
   test-invoc-cmd-ubuntu:
     runs-on: ubuntu-latest
-    if: github.event.inputs.run_invoc_cmd_tests == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_invoc_cmd_tests == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -227,7 +227,7 @@ jobs:
 
   test-invoc-cmd-macos:
     runs-on: macos-latest
-    if: github.event.inputs.run_invoc_cmd_tests == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_invoc_cmd_tests == 'true'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -301,7 +301,7 @@ jobs:
 
   test-invoc-cmd-windows:
     runs-on: windows-latest
-    if: github.event.inputs.run_invoc_cmd_tests == 'true'
+    if: github.event_name == 'pull_request' || github.event.inputs.run_invoc_cmd_tests == 'true'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -967,23 +967,9 @@ class BaseApp(metaclass=Singleton):
             )
 
         test_args = (self.pytest_args or []) + list(args)
-        if self.run_time_info.is_frozen:
-            pkg = self.package_name
-            res = "tests"
-            try:
-                test_dir_ctx = resources.as_file(resources.files(pkg).joinpath(res))
-            except AttributeError:
-                # < python 3.8; `resource.path` deprecated since 3.11
-                test_dir_ctx = resources.path(pkg, res)
-
-            with test_dir_ctx as test_dir:
-                return pytest.main([str(test_dir)] + test_args)
-        else:
-            ret_code = pytest.main(["--pyargs", f"{self.package_name}"] + test_args)
-            if ret_code is not pytest.ExitCode.OK:
-                raise RuntimeError(f"Tests failed with exit code: {str(ret_code)}")
-            else:
-                return ret_code
+        pkg = self.package_name
+        with resources.as_file(resources.files(pkg).joinpath("tests")) as test_dir:
+            return pytest.main([str(test_dir)] + test_args)
 
     def _get_OS_info(self) -> Dict:
         """Get information about the operating system."""


### PR DESCRIPTION
…se we couldn't pass custom CLI options to pytest

refactor: remove python < 3.8 try/except in _run_tests