### PR TITLE
fix: fix `get_active_jobscripts` for SLURM when using `max_array_item…

### DIFF
--- a/hpcflow/sdk/submission/schedulers/slurm.py
+++ b/hpcflow/sdk/submission/schedulers/slurm.py
@@ -416,7 +416,11 @@ class SlurmPosix(Scheduler):
                 _arr_idx = []
                 for i_range_str in arr_idx.strip("[]").split(","):
                     if "-" in i_range_str:
-                        i_args = [int(j) - 1 for j in i_range_str.split("-")]
+                        range_parts = i_range_str.split("-")
+                        if "%" in range_parts[1]:
+                            # indicates max concurrent array items; not needed
+                            range_parts[1] = range_parts[1].split("%")[0]
+                        i_args = [int(j) - 1 for j in range_parts]
                         _arr_idx.extend(list(range(i_args[0], i_args[1] + 1)))
                     else:
                         _arr_idx.append(int(i_range_str) - 1)

--- a/hpcflow/tests/unit/test_slurm.py
+++ b/hpcflow/tests/unit/test_slurm.py
@@ -25,3 +25,14 @@ def test_parse_job_ID_array_simple_mixed_range():
         "30627658",
         [4, 7, 8, 9],
     )
+
+
+def test_parse_job_ID_array_simple_range_with_max_concurrent():
+    assert SlurmPosix._parse_job_IDs("3397752_[9-11%2]") == ("3397752", [8, 9, 10])
+
+
+def test_parse_job_ID_array_simple_multiple_range_max_concurrent():
+    assert SlurmPosix._parse_job_IDs("49203_[3-5%1,9-11%2]") == (
+        "49203",
+        [2, 3, 4, 8, 9, 10],
+    )


### PR DESCRIPTION
…s`; fix #598