### PR TITLE
Add `Workflow.rechunk` method

### DIFF
--- a/.github/workflows/build-exes.yml
+++ b/.github/workflows/build-exes.yml
@@ -254,6 +254,9 @@ jobs:
   build-executables-linux:
     if: github.event.inputs.build_linux == 'true'
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16    
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:

--- a/.github/workflows/build-exes.yml.in
+++ b/.github/workflows/build-exes.yml.in
@@ -254,6 +254,9 @@ jobs:
   build-executables-linux:
     if: github.event.inputs.build_linux == 'true'
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16    
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,12 +445,10 @@ jobs:
 
   release-github-PyPI:
     needs:
-      [
-        bump-version,
-        build-executables,
-        build-executables-linux,
-        make-workflow-benchmark-upload,
-      ]
+      - bump-version
+      - build-executables
+      - build-executables-linux
+      - make-workflow-benchmark-upload
     runs-on: ubuntu-latest
     outputs:
       binary_download_links: ${{ steps.get_binary_download_links.outputs.binary_download_links }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
         if: "!contains(matrix.os, 'windows')"
         working-directory: pyinstaller
         run: ./make.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO 'onefile'
-        
+
       - name: Build with pyinstaller (non-Windows, folder)
         if: "!contains(matrix.os, 'windows')"
         working-directory: pyinstaller
@@ -266,10 +266,10 @@ jobs:
         run: ./compress.ps1 -ExeName 'hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -BuildType 'onedir'
 
       - name: Compress folder (non-windows, folder)
-        if: "!contains(matrix.os, 'windows')" 
+        if: "!contains(matrix.os, 'windows')"
         working-directory: pyinstaller
         run: ./compress.sh hpcflow-${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir 'onedir'
-          
+
       - name: Upload executable artifact (file)
         uses: actions/upload-artifact@v4
         with:
@@ -285,6 +285,9 @@ jobs:
   build-executables-linux:
     runs-on: ubuntu-latest
     needs: bump-version
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
@@ -379,8 +382,8 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
-          - windows-latest      
-        num_elements: 
+          - windows-latest
+        num_elements:
           - 1
           - 100
           - 10000
@@ -416,8 +419,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-            name: benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt
-            path: benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt
+          name: benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt
+          path: benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt
 
   make-workflow-benchmark-upload:
     needs: make-workflow-benchmark
@@ -429,19 +432,25 @@ jobs:
       - run: |
           mkdir benchmarks
       - uses: actions/download-artifact@v4
-        with: 
+        with:
           merge-multiple: true
           path: benchmarks
       - name: zip benchmark results
         run: |
           zip -r ./benchmarks.zip benchmarks
       - uses: actions/upload-artifact@v4
-        with:             
+        with:
           name: benchmarks.zip
           path: benchmarks.zip
 
   release-github-PyPI:
-    needs: [bump-version, build-executables, build-executables-linux, make-workflow-benchmark-upload]
+    needs:
+      [
+        bump-version,
+        build-executables,
+        build-executables-linux,
+        make-workflow-benchmark-upload,
+      ]
     runs-on: ubuntu-latest
     outputs:
       binary_download_links: ${{ steps.get_binary_download_links.outputs.binary_download_links }}

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -190,7 +190,7 @@ jobs:
         if: "!contains(matrix.os, 'windows')"
         working-directory: {{ pyinstaller_dir }}
         run: ./make.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }} INFO 'onefile'{% endraw %}
-        
+
       - name: Build with pyinstaller (non-Windows, folder)
         if: "!contains(matrix.os, 'windows')"
         working-directory: {{ pyinstaller_dir }}
@@ -266,10 +266,10 @@ jobs:
         run: ./compress.ps1 -ExeName '{{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir' -BuildType 'onedir'{% endraw %}
 
       - name: Compress folder (non-windows, folder)
-        if: "!contains(matrix.os, 'windows')" 
+        if: "!contains(matrix.os, 'windows')"
         working-directory: {{ pyinstaller_dir }}
         run: ./compress.sh {{ executable_name }}-{% raw %}${{ needs.bump-version.outputs.new_tag_name }}-${{ matrix.executable_os }}-dir 'onedir'{% endraw %}
-          
+
       - name: Upload executable artifact (file)
         uses: actions/upload-artifact@v4
         with:
@@ -285,6 +285,9 @@ jobs:
   build-executables-linux:
     runs-on: ubuntu-latest
     needs: bump-version
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
     steps:
@@ -379,8 +382,8 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
-          - windows-latest      
-        num_elements: 
+          - windows-latest
+        num_elements:
           - 1
           - 100
           - 10000
@@ -416,8 +419,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-            name: {% raw %}benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt{% endraw %}
-            path: {% raw %}benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt{% endraw %}
+          name: {% raw %}benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt{% endraw %}
+          path: {% raw %}benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt{% endraw %}
 
   make-workflow-benchmark-upload:
     needs: make-workflow-benchmark
@@ -429,19 +432,23 @@ jobs:
       - run: |
           mkdir benchmarks
       - uses: actions/download-artifact@v4
-        with: 
+        with:
           merge-multiple: true
           path: benchmarks
       - name: zip benchmark results
         run: |
           zip -r ./benchmarks.zip benchmarks
       - uses: actions/upload-artifact@v4
-        with:             
+        with:
           name: benchmarks.zip
           path: benchmarks.zip
 
   release-github-PyPI:
-    needs: [bump-version, build-executables, build-executables-linux, make-workflow-benchmark-upload]
+    needs:
+      - bump-version
+      - build-executables
+      - build-executables-linux
+      - make-workflow-benchmark-upload
     runs-on: ubuntu-latest
     outputs:
       binary_download_links: {% raw %}${{ steps.get_binary_download_links.outputs.binary_download_links }}{% endraw %}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ on:
         description: "CLI args to pass verbatim to pytest (integration tests)."
         required: false
         type: string
-        default: ""         
+        default: ""
   pull_request:
     types: [opened, edited, synchronize]
     branches: [main, develop] # have to manually change these
@@ -137,6 +137,9 @@ jobs:
   test-units-CentOS:
     needs: pre-commit
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     if: github.event_name == 'pull_request' || github.event.inputs.unit_tests == 'true'
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
@@ -223,6 +226,9 @@ jobs:
   test-integration-CentOS:
     needs: pre-commit
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     if: github.event_name == 'pull_request' || github.event.inputs.integration_tests == 'true'
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -39,7 +39,7 @@ on:
         description: "CLI args to pass verbatim to pytest (integration tests)."
         required: false
         type: string
-        default: ""         
+        default: ""
   pull_request:
     types: [opened, edited, synchronize]
     branches: [main, develop] # have to manually change these
@@ -137,6 +137,9 @@ jobs:
   test-units-CentOS:
     needs: pre-commit
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     if: github.event_name == 'pull_request' || github.event.inputs.unit_tests == 'true'
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest
@@ -223,6 +226,9 @@ jobs:
   test-integration-CentOS:
     needs: pre-commit
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
     if: github.event_name == 'pull_request' || github.event.inputs.integration_tests == 'true'
     container:
       image: ghcr.io/hpcflow/centos7-poetry:latest

--- a/.github/workflows/test_direct_sub_jupyter_notebook.ipynb
+++ b/.github/workflows/test_direct_sub_jupyter_notebook.ipynb
@@ -54,7 +54,7 @@
     "      p1: 101\n",
     "\"\"\"\n",
     "wk = app.Workflow.from_YAML_string(YAML_str=wk_yaml, path=gettempdir())\n",
-    "wk.submit(wait=True)\n",
+    "wk.submit(wait=True, status=False)\n",
     "assert wk.tasks[0].elements[0].outputs.p2.value == \"201\""
    ]
   }

--- a/hpcflow/sdk/cli.py
+++ b/hpcflow/sdk/cli.py
@@ -31,6 +31,8 @@ from hpcflow.sdk.cli_common import (
     zip_path_opt,
     zip_overwrite_opt,
     zip_log_opt,
+    zip_include_execute_opt,
+    zip_include_rechunk_backups_opt,
     unzip_path_opt,
     unzip_log_opt,
     rechunk_backup_opt,
@@ -428,11 +430,28 @@ def _make_workflow_CLI(app):
     @zip_path_opt
     @zip_overwrite_opt
     @zip_log_opt
+    @zip_include_execute_opt
+    @zip_include_rechunk_backups_opt
     @click.pass_context
-    def zip_workflow(ctx, path, overwrite, log):
+    def zip_workflow(
+        ctx,
+        path,
+        overwrite,
+        log,
+        include_execute,
+        include_rechunk_backups,
+    ):
         """Generate a copy of the workflow in the zip file format in the current working
         directory."""
-        click.echo(ctx.obj["workflow"].zip(path=path, overwrite=overwrite, log=log))
+        click.echo(
+            ctx.obj["workflow"].zip(
+                path=path,
+                overwrite=overwrite,
+                log=log,
+                include_execute=include_execute,
+                include_rechunk_backups=include_rechunk_backups,
+            )
+        )
 
     @workflow.command(name="unzip")
     @unzip_path_opt
@@ -745,8 +764,18 @@ def _make_zip_CLI(app):
     @zip_path_opt
     @zip_overwrite_opt
     @zip_log_opt
+    @zip_include_execute_opt
+    @zip_include_rechunk_backups_opt
     @workflow_ref_type_opt
-    def zip_workflow(workflow_ref, path, overwrite, log, ref_type):
+    def zip_workflow(
+        workflow_ref,
+        path,
+        overwrite,
+        log,
+        include_execute,
+        include_rechunk_backups,
+        ref_type,
+    ):
         """Generate a copy of the specified workflow in the zip file format in the
         current working directory.
 
@@ -755,7 +784,15 @@ def _make_zip_CLI(app):
         """
         workflow_path = app._resolve_workflow_reference(workflow_ref, ref_type)
         wk = app.Workflow(workflow_path)
-        click.echo(wk.zip(path=path, overwrite=overwrite, log=log))
+        click.echo(
+            wk.zip(
+                path=path,
+                overwrite=overwrite,
+                log=log,
+                include_execute=include_execute,
+                include_rechunk_backups=include_rechunk_backups,
+            )
+        )
 
     return zip_workflow
 

--- a/hpcflow/sdk/cli_common.py
+++ b/hpcflow/sdk/cli_common.py
@@ -151,3 +151,23 @@ unzip_path_opt = click.option(
     ),
 )
 unzip_log_opt = click.option("--log", help="Path to a log file to use during unzipping.")
+rechunk_backup_opt = click.option(
+    "--backup/--no-backup",
+    default=True,
+    help=("First copy a backup of the array to a directory ending in `.bak`."),
+)
+rechunk_chunk_size_opt = click.option(
+    "--chunk-size",
+    type=click.INT,
+    default=None,
+    help=(
+        "New chunk size (array items per chunk). If unset (as by default), the array "
+        "will be rechunked to a single chunk array (i.e with a chunk size equal to the "
+        "array's shape)."
+    ),
+)
+rechunk_status_opt = click.option(
+    "--status/--no-status",
+    default=True,
+    help="If True, display a live status to track rechunking progress.",
+)

--- a/hpcflow/sdk/cli_common.py
+++ b/hpcflow/sdk/cli_common.py
@@ -141,6 +141,8 @@ zip_overwrite_opt = click.option(
     help="If set, any existing file will be overwritten.",
 )
 zip_log_opt = click.option("--log", help="Path to a log file to use during zipping.")
+zip_include_execute_opt = click.option("--include-execute", is_flag=True)
+zip_include_rechunk_backups_opt = click.option("--include-rechunk-backups", is_flag=True)
 unzip_path_opt = click.option(
     "--path",
     default=".",

--- a/hpcflow/sdk/core/workflow.py
+++ b/hpcflow/sdk/core/workflow.py
@@ -1696,7 +1696,14 @@ class Workflow:
 
         return wk
 
-    def zip(self, path=".", log=None, overwrite=False) -> str:
+    def zip(
+        self,
+        path=".",
+        log=None,
+        overwrite=False,
+        include_execute=False,
+        include_rechunk_backups=False,
+    ) -> str:
         """
         Parameters
         ----------
@@ -1705,7 +1712,13 @@ class Workflow:
             directory, the zip file will be created within this directory. Otherwise,
             this path is assumed to be the full file path to the new zip file.
         """
-        return self._store.zip(path=path, log=log, overwrite=overwrite)
+        return self._store.zip(
+            path=path,
+            log=log,
+            overwrite=overwrite,
+            include_execute=include_execute,
+            include_rechunk_backups=include_rechunk_backups,
+        )
 
     def unzip(self, path=".", log=None) -> str:
         """

--- a/hpcflow/sdk/core/workflow.py
+++ b/hpcflow/sdk/core/workflow.py
@@ -2943,6 +2943,34 @@ class Workflow:
                     final_runs[loop_name].append(final[0])
         return dict(final_runs)
 
+    def rechunk_runs(
+        self,
+        chunk_size: Optional[int] = None,
+        backup: Optional[bool] = True,
+        status: Optional[bool] = True,
+    ):
+        self._store.rechunk_runs(chunk_size=chunk_size, backup=backup, status=status)
+
+    def rechunk_parameter_base(
+        self,
+        chunk_size: Optional[int] = None,
+        backup: Optional[bool] = True,
+        status: Optional[bool] = True,
+    ):
+        self._store.rechunk_parameter_base(
+            chunk_size=chunk_size, backup=backup, status=status
+        )
+
+    def rechunk(
+        self,
+        chunk_size: Optional[int] = None,
+        backup: Optional[bool] = True,
+        status: Optional[bool] = True,
+    ):
+        """Rechunk metadata/runs and parameters/base arrays."""
+        self.rechunk_runs(chunk_size=chunk_size, backup=backup, status=status)
+        self.rechunk_parameter_base(chunk_size=chunk_size, backup=backup, status=status)
+
 
 @dataclass
 class WorkflowBlueprint:

--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -1154,7 +1154,14 @@ class ZarrPersistentStore(PersistentStore):
         with self.using_resource("attrs", action="read") as attrs:
             return attrs["name"]
 
-    def zip(self, path=".", log=None, overwrite=False):
+    def zip(
+        self,
+        path=".",
+        log=None,
+        overwrite=False,
+        include_execute=False,
+        include_rechunk_backups=False,
+    ):
         """
         Parameters
         ----------
@@ -1190,10 +1197,17 @@ class ZarrPersistentStore(PersistentStore):
             add_pw_to="target_options",
         )
         dst_zarr_store = zarr.storage.FSStore(url="", fs=zfs)
+        excludes = []
+        if not include_execute:
+            excludes.append("execute")
+        if not include_rechunk_backups:
+            excludes.append("runs.bak")
+            excludes.append("base.bak")
+
         zarr.convenience.copy_store(
             src_zarr_store,
             dst_zarr_store,
-            excludes="execute",
+            excludes=excludes or None,
             log=log,
         )
         del zfs  # ZipFileSystem remains open for instance lifetime

--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -1356,3 +1356,12 @@ class ZarrZipPersistentStore(ZarrPersistentStore):
     def delete_no_confirm(self) -> None:
         # `ZipFileSystem.rm()` does not seem to be implemented.
         raise NotImplementedError()
+
+    def _rechunk_arr(
+        self,
+        arr,
+        chunk_size: Optional[int] = None,
+        backup: Optional[bool] = True,
+        status: Optional[bool] = True,
+    ):
+        raise NotImplementedError

--- a/hpcflow/tests/unit/test_persistence.py
+++ b/hpcflow/tests/unit/test_persistence.py
@@ -1,4 +1,6 @@
-from importlib import resources
+from pathlib import Path
+import numpy as np
+import zarr
 import pytest
 from hpcflow.sdk.core.test_utils import make_test_data_YAML_workflow
 from hpcflow.sdk.persistence.base import StoreEAR, StoreElement, StoreElementIter
@@ -239,3 +241,118 @@ def test_make_zarr_store_no_compressor(null_config, tmp_path):
         store="zarr",
         store_kwargs={"compressor": None},
     )
+
+
+@pytest.mark.integration
+def test_zarr_rechunk_data_equivalent(null_config, tmp_path):
+    t1 = hf.Task(
+        schema=hf.task_schemas.test_t1_conditional_OS,
+        inputs={"p1": 101},
+        repeats=3,
+    )
+    wk = hf.Workflow.from_template_data(
+        tasks=[t1],
+        template_name="test_run_rechunk",
+        workflow_name="test_run_rechunk",
+        path=tmp_path,
+    )
+    wk.submit(wait=True, status=False, add_to_known=False)
+    wk.rechunk_runs(backup=True, status=False, chunk_size=None)  # None -> one chunk
+
+    arr = wk._store._get_EARs_arr()
+    assert arr.chunks == arr.shape
+
+    bak_path = (Path(wk.path) / arr.path).with_suffix(".bak")
+    arr_bak = zarr.open(bak_path)
+
+    assert arr_bak.chunks == (1,)
+
+    # check backup and new runs data are equal:
+    assert np.all(arr[:] == arr_bak[:])
+
+    # check attributes are equal:
+    assert arr.attrs.asdict() == arr_bak.attrs.asdict()
+
+
+@pytest.mark.integration
+def test_zarr_rechunk_data_equivalent_custom_chunk_size(null_config, tmp_path):
+    t1 = hf.Task(
+        schema=hf.task_schemas.test_t1_conditional_OS,
+        inputs={"p1": 101},
+        repeats=3,
+    )
+    wk = hf.Workflow.from_template_data(
+        tasks=[t1],
+        template_name="test_run_rechunk",
+        workflow_name="test_run_rechunk",
+        path=tmp_path,
+    )
+    wk.submit(wait=True, status=False, add_to_known=False)
+    wk.rechunk_runs(backup=True, status=False, chunk_size=2)
+
+    arr = wk._store._get_EARs_arr()
+    assert arr.chunks == (2,)
+
+    bak_path = (Path(wk.path) / arr.path).with_suffix(".bak")
+    arr_bak = zarr.open(bak_path)
+
+    assert arr_bak.chunks == (1,)
+
+    # check backup and new runs data are equal:
+    assert np.all(arr[:] == arr_bak[:])
+
+
+@pytest.mark.integration
+def test_zarr_rechunk_data_no_backup_load_runs(null_config, tmp_path):
+    t1 = hf.Task(
+        schema=hf.task_schemas.test_t1_conditional_OS,
+        inputs={"p1": 101},
+        repeats=3,
+    )
+    wk = hf.Workflow.from_template_data(
+        tasks=[t1],
+        template_name="test_run_rechunk",
+        workflow_name="test_run_rechunk",
+        path=tmp_path,
+    )
+    wk.submit(wait=True, status=False, add_to_known=False)
+    wk.rechunk_runs(backup=False, status=False)
+
+    arr = wk._store._get_EARs_arr()
+
+    bak_path = (Path(wk.path) / arr.path).with_suffix(".bak")
+    assert not bak_path.is_file()
+
+    # check we can load runs:
+    runs = wk._store._get_persistent_EARs(id_lst=list(range(wk.num_EARs)))
+    run_ID = []
+    for i in runs.values():
+        run_ID.append(i.id_)
+
+
+@pytest.mark.integration
+def test_zarr_rechunk_data_no_backup_load_parameter_base(null_config, tmp_path):
+    t1 = hf.Task(
+        schema=hf.task_schemas.test_t1_conditional_OS,
+        inputs={"p1": 101},
+        repeats=3,
+    )
+    wk = hf.Workflow.from_template_data(
+        tasks=[t1],
+        template_name="test_run_rechunk",
+        workflow_name="test_run_rechunk",
+        path=tmp_path,
+    )
+    wk.submit(wait=True, status=False, add_to_known=False)
+    wk.rechunk_parameter_base(backup=False, status=False)
+
+    arr = wk._store._get_parameter_base_array()
+
+    bak_path = (Path(wk.path) / arr.path).with_suffix(".bak")
+    assert not bak_path.is_file()
+
+    # check we can load parameters:
+    params = wk.get_all_parameters()
+    param_IDs = []
+    for i in params:
+        param_IDs.append(i.id_)


### PR DESCRIPTION
This rechunks the `metadata/runs` and/or the `parameters/base` to use (by default) a single chunk. At submission and execution, these arrays must be 1-chunk-per-item to allow for multi-process writing. So rechunking can vastly reduce the number of files stored in the workflow directory, which improves read performance, especially on network file systems.