### PR TITLE
Fix two type "errors"

### DIFF
--- a/hpcflow/sdk/core/utils.py
+++ b/hpcflow/sdk/core/utils.py
@@ -124,7 +124,9 @@ def check_valid_py_identifier(name: str) -> str:
 
 
 @overload
-def group_by_dict_key_values(lst: list[dict[T, T2]], key: T) -> list[list[dict[T, T2]]]:
+def group_by_dict_key_values(  # type: ignore[overload-overlap]
+    lst: list[dict[T, T2]], key: T
+) -> list[list[dict[T, T2]]]:
     ...
 
 

--- a/hpcflow/sdk/typing.py
+++ b/hpcflow/sdk/typing.py
@@ -3,7 +3,7 @@ Common type aliases.
 """
 from __future__ import annotations
 from dataclasses import InitVar
-from typing import ClassVar, Final, TypeVar, cast, TYPE_CHECKING
+from typing import Any, ClassVar, Final, TypeVar, cast, TYPE_CHECKING
 from typing_extensions import NotRequired, TypeAlias, TypedDict
 from pathlib import Path
 import re
@@ -153,16 +153,16 @@ def hydrate(cls: type[_T]) -> type[_T]:
     Partially hydrates the annotations on fields in a class, so that a @dataclass
     annotation can recognise that ClassVar-annotated fields are class variables.
     """
-    anns = {}
+    anns: dict[str, Any] = {}
     for f, a in cls.__annotations__.items():
         if isinstance(a, str):
             m = _CLASS_VAR_RE.match(a)
             if m:
-                anns[f] = ClassVar[m[1]]
+                anns[f] = cast(Any, ClassVar[m[1]])
                 continue
             m = _INIT_VAR_RE.match(a)
             if m:
-                anns[f] = InitVar(cast(type, m[1]))
+                anns[f] = cast(Any, InitVar(cast(type, m[1])))
                 continue
         anns[f] = a
     cls.__annotations__ = anns


### PR DESCRIPTION
They're both spots where we're doing something a bit tricky. One is a formally ambiguous overload (can't be helped as the actual type model seems to be impossible to express, and does mean that the rest of the code is better) and the other is a place with a weird hack to work around a fight between `typing` and `dataclasses` over whether types are evaluated during parsing or not. (That fight is part of why `from __future__ import annotations` ia still needed.)