### PR TITLE
Add a dependabot ruleset [skip release]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+version: 2
+updates:
+  - directory: /
+    package-ecosystem: pip
+    schedule:
+      interval: weekly
+    reviewers:
+      - aplowman
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+    reviewers:
+      - aplowman


### PR DESCRIPTION
Dependabot supports poetry these days (with the 'pip' ecosystem tag) so we ought to use it. This will help us avoid security problems with dependencies (and may also populate - private - security advisories if necessary).