### PR TITLE
Switch CODEOWNERS to use a team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @aplowman
-/.github/ @aplowman
-/pyinstaller/ @cjfullerton
+* @hpcflow/reviewers


### PR DESCRIPTION
This updates the `CODEOWNERS` file to use a team for who can review files, rather than individual people.

The team is currently:
* @aplowman 
* @dkfellows 
* @gcapes 

See https://github.com/LightForm-group/non-repo-issues/issues/40 for rationale.

(I've removed Chris Fullerton; he's busy elsewhere.)

>[!NOTE]
>To correctly work, the team `@hpcflow/reviewers` must _itself_ be given write access to the repository.