### PR TITLE
Update CODEOWNERS [skip release]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hpcflow/reviewers
+* @hpcflow/reviewers @aplowman


### PR DESCRIPTION
I think I'd like to maintain the ability to merge without approval of the other reviewers (at least for now---I do understand the oversight benefits of this approach though), which our current setup does not allow for. For example in MatFlow, I cannot seem to merge these, as I am the owner and the review request is automatically triggered: https://github.com/hpcflow/matflow-new/pull/355, https://github.com/hpcflow/matflow-new/pull/282.

If I understand the [code owners docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-branch-protection) correctly, adding my handle here will allow either @hpcflow/reviewers _or_ me to approve, so we maintain the desired effect of the previous update (https://github.com/hpcflow/hpcflow-new/pull/765) to the codeowners file (namely, I don't need to approve every PR for it to be merged).