### PR TITLE
build: group dependabot PRs for each package ecosystem [skip release]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,17 @@ updates:
       interval: weekly
     reviewers:
       - aplowman
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
   - directory: /
     package-ecosystem: github-actions
     schedule:
       interval: weekly
     reviewers:
       - aplowman
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
The aim is to avoid a large number of PRs from dependabot.

https://github.blog/news-insights/product-news/a-faster-way-to-manage-version-updates-with-dependabot/#how-it-works