### PR TITLE
Revert "Update CODEOWNERS [skip release]"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hpcflow/reviewers @aplowman
+* @hpcflow/reviewers


### PR DESCRIPTION
Reverts hpcflow/hpcflow-new#770

This was ineffective and I found the "proper" solution, which is to allow admin's (i.e. me) to optionally explicitly bypass branch protection rules for each PR, via unticking: `Do not allow bypassing the above settings` in branch protection settings.