### PR TITLE
fix: move `from __future__` statements to top of generated combined python script

### DIFF
--- a/hpcflow/data/scripts/import_future_script.py
+++ b/hpcflow/data/scripts/import_future_script.py
@@ -3,5 +3,5 @@ from __future__ import annotations
 
 def import_future_script():
     """Used to test the `__future__` import is moved to the top of the file in the
-    generated script in the case of `resources.combine_script == True`"""
+    generated script in the case of `resources.combine_scripts == True`"""
     pass

--- a/hpcflow/data/scripts/import_future_script.py
+++ b/hpcflow/data/scripts/import_future_script.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def import_future_script():
+    """Used to test the `__future__` import is moved to the top of the file in the
+    generated script in the case of `resources.combine_script == True`"""
+    pass

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -24,6 +24,7 @@ from hpcflow.sdk.core.errors import (
 from hpcflow.sdk.typing import hydrate
 from hpcflow.sdk.core.json_like import ChildObjectSpec, JSONLike
 from hpcflow.sdk.core.utils import nth_value, parse_timestamp, current_timestamp
+from hpcflow.sdk.utils.strings import extract_py_from_future_imports
 from hpcflow.sdk.log import TimeIt
 from hpcflow.sdk.submission.schedulers import QueuedScheduler
 from hpcflow.sdk.submission.schedulers.direct import DirectScheduler
@@ -1942,10 +1943,13 @@ class Jobscript(JSONLike):
         tab_indent = "    "
 
         script_funcs_lst: list[str] = []
+        future_imports: set[str] = set()
         for act_name, (_, snip_path) in script_data.items():
             main_func_name = snip_path.stem
             with snip_path.open("rt") as fp:
                 script_str = fp.read()
+            script_str, future_imports_i = extract_py_from_future_imports(script_str)
+            future_imports.update(future_imports_i)
             script_funcs_lst.append(
                 dedent(
                     """\
@@ -2325,13 +2329,22 @@ class Jobscript(JSONLike):
             func_invoc_lines=indent(func_invoc_lines, tab_indent * 4),
         )
 
+        future_imports_str = (
+            f"from __future__ import {', '.join(future_imports)}\n\n"
+            if future_imports
+            else ""
+        )
         script = dedent(
             """\
-            {script_funcs}
+            {future_imports_str}{script_funcs}
             if __name__ == "__main__":
             {main}
         """
-        ).format(script_funcs=script_funcs, main=indent(main, tab_indent))
+        ).format(
+            future_imports_str=future_imports_str,
+            script_funcs=script_funcs,
+            main=indent(main, tab_indent),
+        )
 
         num_elems = [i.num_elements for i in self.blocks]
         num_acts = [len(i) for i in action_scripts]

--- a/hpcflow/sdk/utils/strings.py
+++ b/hpcflow/sdk/utils/strings.py
@@ -1,4 +1,5 @@
 from typing import Iterable
+import re
 
 
 def shorten_list_str(
@@ -31,3 +32,30 @@ def shorten_list_str(
         lst_short = lst[:start_num] + ["..."] + lst[-end_num:]
 
     return "[" + ", ".join(f"{i}" for i in lst_short) + "]"
+
+
+def extract_py_from_future_imports(py_str: str) -> tuple[str, set[str]]:
+    """
+    Remove any `from __future__ import <feature>` lines from a string of Python code, and
+    return the modified string, and a list of `<feature>`s that were imported.
+
+    Notes
+    -----
+    This is required when generated a combined-scripts jobscript that concatenates
+    multiple Python scripts into one script. If `__future__` statements are included in
+    these individual scripts, they must be moved to the top of the file [1].
+
+    References
+    ----------
+    [1] https://docs.python.org/3/reference/simple_stmts.html#future-statements
+
+    """
+
+    pattern = r"^from __future__ import (.*)\n"
+    if future_imports := (set(re.findall(pattern, py_str, flags=re.MULTILINE) or ())):
+        future_imports = {
+            j.strip() for i in future_imports for j in i.split(",") if j.strip()
+        }
+        py_str = re.sub(pattern, "", py_str, flags=re.MULTILINE)
+
+    return (py_str, future_imports)

--- a/hpcflow/tests/scripts/test_main_scripts.py
+++ b/hpcflow/tests/scripts/test_main_scripts.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 from hpcflow.app import app as hf
+from hpcflow.sdk.core.enums import EARStatus
 from hpcflow.sdk.core.test_utils import P1_parameter_cls as P1
 
 # note: when testing the frozen app, we might not have MatFlow installed in the built in
@@ -1332,3 +1333,29 @@ def test_combine_scripts_script_data_multiple_input_file_formats(
     assert isinstance(t1_p3, hf.ElementParameter)
     assert t0_p2.value == p1_val + 100
     assert t1_p3.value == p1_val + 100
+
+
+@pytest.mark.integration
+@pytest.mark.skipif("hf.run_time_info.is_frozen")
+def test_combine_scripts_from_future_import(null_config, tmp_path: Path):
+    s1 = hf.TaskSchema(
+        objective="t1",
+        actions=[
+            hf.Action(
+                script="<<script:import_future_script.py>>",
+                script_exe="python_script",
+                environments=[hf.ActionEnvironment(environment="python_env")],
+            ),
+        ],
+    )
+
+    wk = hf.Workflow.from_template_data(
+        template_name="test_future_import",
+        tasks=[hf.Task(schema=s1)],
+        resources={"any": {"combine_scripts": True}},
+        path=tmp_path,
+    )
+    wk.submit(status=False, add_to_known=False, wait=True)
+
+    run = wk.get_EARs_from_IDs([0])[0]
+    assert run.status is EARStatus.success

--- a/hpcflow/tests/unit/utils/test_strings.py
+++ b/hpcflow/tests/unit/utils/test_strings.py
@@ -1,0 +1,97 @@
+from textwrap import dedent
+
+from hpcflow.sdk.utils.strings import extract_py_from_future_imports
+
+
+def test_extract_py_from_future_imports_none():
+    py_str = dedent(
+        """\
+
+    def my_function():
+        print("blah!")
+    """
+    )
+    new_str, imports = extract_py_from_future_imports(py_str)
+    assert imports == set()
+    assert new_str == py_str
+
+
+def test_extract_py_from_future_imports_single():
+    py_str = dedent(
+        """\
+    from __future__ import annotations
+
+    def my_function():
+        print("blah!")
+    """
+    )
+    new_str, imports = extract_py_from_future_imports(py_str)
+    assert imports == {"annotations"}
+    assert new_str == dedent(
+        """\
+
+    def my_function():
+        print("blah!")
+    """
+    )
+
+
+def test_extract_py_from_future_imports_multi():
+    py_str = dedent(
+        """\
+    from __future__ import annotations, feature_2
+
+    def my_function():
+        print("blah!")
+    """
+    )
+    new_str, imports = extract_py_from_future_imports(py_str)
+    assert imports == {"annotations", "feature_2"}
+    assert new_str == dedent(
+        """\
+
+    def my_function():
+        print("blah!")
+    """
+    )
+
+
+def test_extract_py_from_future_imports_trailing_comma():
+    py_str = dedent(
+        """\
+    from __future__ import annotations,
+
+    def my_function():
+        print("blah!")
+    """
+    )
+    new_str, imports = extract_py_from_future_imports(py_str)
+    assert imports == {"annotations"}
+    assert new_str == dedent(
+        """\
+
+    def my_function():
+        print("blah!")
+    """
+    )
+
+
+def test_extract_py_from_future_imports_multi_lines():
+    py_str = dedent(
+        """\
+    from __future__ import annotations, feature_2
+    from __future__ import feature_2, feature_3,
+
+    def my_function():
+        print("blah!")
+    """
+    )
+    new_str, imports = extract_py_from_future_imports(py_str)
+    assert imports == {"annotations", "feature_2", "feature_3"}
+    assert new_str == dedent(
+        """\
+
+    def my_function():
+        print("blah!")
+    """
+    )


### PR DESCRIPTION
`from __future__ import ...` statements must always be at the top of the file. But when we generate a combined Python script (i.e. `resources.combine_scripts == True`), constitutive scripts may individuallly contain such statements. Thus we need to combine and move all occurances to the top of the generated script.