### PR TITLE
Baseline resource level for SLURM partition select

### DIFF
--- a/hpcflow/sdk/submission/schedulers/slurm.py
+++ b/hpcflow/sdk/submission/schedulers/slurm.py
@@ -300,6 +300,11 @@ class SlurmPosix(QueuedScheduler):
         Check whether a partition (part_name, part_info) matches the requested number
         of cores and nodes.
         """
+        if num_cores is None and num_cores_per_node is None and num_nodes is None:
+            # If we have no guidance for what to look for, assume we want just one core.
+            # If more is needed, the user will need to specify, but they'd probably
+            # need to do that anyway; this is a best guess when told nothing!
+            num_cores = 1
         part_num_cores = part_info.get("num_cores", [])
         part_num_cores_per_node = part_info.get("num_cores_per_node", [])
         part_num_nodes = part_info.get("num_nodes", [])

--- a/hpcflow/sdk/submission/schedulers/slurm.py
+++ b/hpcflow/sdk/submission/schedulers/slurm.py
@@ -284,7 +284,8 @@ class SlurmPosix(QueuedScheduler):
         Test if information is present on both sides, and also matches.
         """
         return bool(
-            num_req is None or (part_have and cls.is_num_cores_supported(num_req, part_have))
+            num_req is None
+            or (part_have and cls.is_num_cores_supported(num_req, part_have))
         )
 
     @classmethod

--- a/hpcflow/sdk/submission/schedulers/slurm.py
+++ b/hpcflow/sdk/submission/schedulers/slurm.py
@@ -284,7 +284,7 @@ class SlurmPosix(QueuedScheduler):
         Test if information is present on both sides, and also matches.
         """
         return bool(
-            num_req and part_have and cls.is_num_cores_supported(num_req, part_have)
+            num_req is None or (part_have and cls.is_num_cores_supported(num_req, part_have))
         )
 
     @classmethod
@@ -300,11 +300,6 @@ class SlurmPosix(QueuedScheduler):
         Check whether a partition (part_name, part_info) matches the requested number
         of cores and nodes.
         """
-        if num_cores is None and num_cores_per_node is None and num_nodes is None:
-            # If we have no guidance for what to look for, assume we want just one core.
-            # If more is needed, the user will need to specify, but they'd probably
-            # need to do that anyway; this is a best guess when told nothing!
-            num_cores = 1
         part_num_cores = part_info.get("num_cores", [])
         part_num_cores_per_node = part_info.get("num_cores_per_node", [])
         part_num_nodes = part_info.get("num_nodes", [])

--- a/hpcflow/tests/data/workflow_2_slurm.yaml
+++ b/hpcflow/tests/data/workflow_2_slurm.yaml
@@ -1,0 +1,24 @@
+template_components:
+  task_schemas:
+  - objective: locate_bash
+    outputs:
+      - parameter: bash_location
+    actions:
+    - commands:
+      - command: which bash
+        stdout: <<parameter:bash_location>>
+      environments:
+      - scope:
+          type: any
+        environment: null_env
+
+tasks:
+- schema: locate_bash
+
+resources:
+  any:
+    scheduler_args:
+      directives:
+        --time: 00:30:00
+#        --partition: serial
+    num_cores: 1

--- a/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
+++ b/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
@@ -27,6 +27,14 @@ def test_workflow_2(tmp_path: Path, null_config):
 def test_slurm_partition_select():
     slurm = hf.SlurmPosix()
     resources = hf.ElementResources()
-    config = {"partitions": {"serial": {"num_nodes": [1,1,1], "num_cores": [1,1,1], "num_cores_per_node": [1,1,1]}}}
+    config = {
+        "partitions": {
+            "serial": {
+                "num_nodes": [1, 1, 1],
+                "num_cores": [1, 1, 1],
+                "num_cores_per_node": [1, 1, 1],
+            }
+        }
+    }
     slurm.process_resources(resources, config)
     assert resources.SLURM_partition == "serial"

--- a/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
+++ b/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
@@ -12,3 +12,13 @@ def test_workflow_1(tmp_path: Path, null_config):
     p2 = wk.tasks[0].elements[0].outputs.p2
     assert isinstance(p2, hf.ElementParameter)
     assert p2.value == "201"
+
+
+@pytest.mark.slurm
+def test_workflow_2(tmp_path: Path, null_config):
+    hf.config.add_scheduler("slurm")
+    wk = make_test_data_YAML_workflow("workflow_2_slurm.yaml", path=tmp_path)
+    wk.submit(wait=True, add_to_known=False)
+    bash_location = wk.tasks[0].elements[0].outputs.bash_location
+    assert isinstance(bash_location, hf.ElementParameter)
+    assert "bash" in bash_location.value

--- a/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
+++ b/hpcflow/tests/schedulers/slurm/test_slurm_submission.py
@@ -22,3 +22,11 @@ def test_workflow_2(tmp_path: Path, null_config):
     bash_location = wk.tasks[0].elements[0].outputs.bash_location
     assert isinstance(bash_location, hf.ElementParameter)
     assert "bash" in bash_location.value
+
+
+def test_slurm_partition_select():
+    slurm = hf.SlurmPosix()
+    resources = hf.ElementResources()
+    config = {"partitions": {"serial": {"num_nodes": [1,1,1], "num_cores": [1,1,1], "num_cores_per_node": [1,1,1]}}}
+    slurm.process_resources(resources, config)
+    assert resources.SLURM_partition == "serial"


### PR DESCRIPTION
If we have no guidance for what to look for, assume we want just one core. If more is needed, the user will need to specify, but they'd probably need to do that anyway; this is a best guess when told nothing!

I _think_ this fixes #801 