### PR TITLE
Fix passing regex-style command files to input file generators

### DIFF
--- a/hpcflow/sdk/core/actions.py
+++ b/hpcflow/sdk/core/actions.py
@@ -914,8 +914,16 @@ class ElementActionRun(AppAware):
         kwargs: dict[str, Any] = {}
         if self.action.is_IFG:
             ifg = self.action.input_file_generators[0]
-            path = ifg.input_file.name.value()
-            assert isinstance(path, str)
+            file_name = ifg.input_file.name
+            if file_name.is_regex:
+                # pass to the IFG the label rather than name (there is no point searching
+                # with the regular expression via `name.value()`; the file(s) won't exist
+                # yet!):
+                path = ifg.input_file.label
+            else:
+                path_ = ifg.input_file.name.value()
+                assert isinstance(path_, str)
+                path = path_
             kwargs["path"] = Path(path)
             kwargs.update(self.get_IFG_input_values(raise_on_unset=raise_on_unset))
 

--- a/hpcflow/sdk/core/actions.py
+++ b/hpcflow/sdk/core/actions.py
@@ -913,12 +913,12 @@ class ElementActionRun(AppAware):
         """
         kwargs: dict[str, Any] = {}
         if self.action.is_IFG:
-            ifg = self.action.input_file_generators[0]
-            if (fn_spec := ifg.input_file.name).is_regex:
+            input_file = self.action.input_file_generators[0].input_file
+            if (fn_spec := input_file.name).is_regex:
                 # pass to the IFG the label rather than name (there is no point searching
                 # with the regular expression via `name.value()`; the file(s) won't exist
                 # yet!):
-                path = ifg.input_file.label
+                path = input_file.label
             else:
                 path_ = fn_spec.value()
                 assert isinstance(path_, str)

--- a/hpcflow/sdk/core/actions.py
+++ b/hpcflow/sdk/core/actions.py
@@ -914,14 +914,13 @@ class ElementActionRun(AppAware):
         kwargs: dict[str, Any] = {}
         if self.action.is_IFG:
             ifg = self.action.input_file_generators[0]
-            file_name = ifg.input_file.name
-            if file_name.is_regex:
+            if (fn_spec := ifg.input_file.name).is_regex:
                 # pass to the IFG the label rather than name (there is no point searching
                 # with the regular expression via `name.value()`; the file(s) won't exist
                 # yet!):
                 path = ifg.input_file.label
             else:
-                path_ = ifg.input_file.name.value()
+                path_ = fn_spec.value()
                 assert isinstance(path_, str)
                 path = path_
             kwargs["path"] = Path(path)

--- a/hpcflow/tests/unit/test_group.py
+++ b/hpcflow/tests/unit/test_group.py
@@ -91,3 +91,25 @@ def test_group_raise_no_elements(null_config, tmp_path: Path):
             path=tmp_path,
             tasks=[t1, t2],
         )
+
+
+def test_group_on_input_only_task(null_config, tmp_path: Path):
+
+    s1 = hf.TaskSchema(objective="t1", inputs=[hf.SchemaInput("p1")])
+    s2 = hf.TaskSchema(objective="t2", inputs=[hf.SchemaInput("p1", group="all")])
+
+    t1 = hf.Task(
+        schema=s1,
+        inputs={"p1": 100},
+        repeats=2,
+        groups=[hf.ElementGroup(name="all")],  # define a group on a task with no actions
+    )
+    t2 = hf.Task(schema=s2)
+
+    wk = hf.Workflow.from_template_data(
+        template_name="test_input_group",
+        path=tmp_path,
+        tasks=[t1, t2],
+    )
+    assert wk.tasks.t1.num_elements == 2
+    assert wk.tasks.t2.num_elements == 1


### PR DESCRIPTION
If we have a variable number of input files that are defined using a regular expression, and these files are to be generated via an input file generator, then we cannot resolve those files when passing a `Path` to the input file generator (which should represent the file path that is to be created), because the files won't exist yet.

Instead, in this fix, we just pass the command file label, because we have to pass something.

This PR includes an unrelated test addition (groups defined on action-less tasks).