### PR TITLE
perf: always use single-chunk arrays for numpy parameter data

### DIFF
--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -124,7 +124,7 @@ def _encode_numpy_array(
     new_idx = (
         max((int(i.removeprefix("arr_")) for i in param_arr_group.keys()), default=-1) + 1
     )
-    param_arr_group.create_dataset(name=f"arr_{new_idx}", data=obj)
+    param_arr_group.create_dataset(name=f"arr_{new_idx}", data=obj, chunks=obj.shape)
     type_lookup["arrays"].append([path, new_idx])
 
     return len(type_lookup["arrays"]) - 1


### PR DESCRIPTION
For large workflows (1k+ elements), workflow operations/interactions can become very slow. One reason for this (especially on network file systems) is the large number of parameter data files. This PR is a small change that forces all parameter data Numpy arrays to be encoded as single-chunk Zarr arrays (i.e. represented on disk as one data file and one metadata file). This will have a moderate effect on the total number of files in large workflows (typically I expect a ~10% reduction, although it depends entirely on what data the user is choosing to save, and how many increments are in their simulations etc).

In future, we would ideally be able to choose a chunking strategy for a given parameter, but I think this is the best strategy for now, given the typical "large" workflows that we run in MatFlow are usually many small simulations rather than few large simulations.