### PR TITLE
fix: refactor some enums to placate mypy 1.16

### DIFF
--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -3583,7 +3583,7 @@ class BaseApp(metaclass=Singleton):
                         )
                         all_cells["status"] = "/".join(
                             js_state.rich_repr
-                            for js_state in sorted(act_js_states, key=lambda x: x.value)
+                            for js_state in sorted(act_js_states, key=lambda x: x.id)
                         )
                     else:
                         if deleted:
@@ -3645,7 +3645,7 @@ class BaseApp(metaclass=Singleton):
                         all_cells["actions_compact"] = " | ".join(
                             f"[{k.colour}]{k.symbol}[/{k.colour}]:{v}"  # type: ignore
                             for k, v in dict(
-                                sorted(EAR_stat_count.items(), key=lambda x: x[0].value)
+                                sorted(EAR_stat_count.items(), key=lambda x: x[0].id)
                             ).items()
                         )
                     else:

--- a/hpcflow/sdk/core/enums.py
+++ b/hpcflow/sdk/core/enums.py
@@ -26,45 +26,85 @@ class ActionScopeType(Enum):
 
 
 @dataclass(frozen=True)
-class _EARStatus:
+class _ReportableStateData:
     """
-    Model of the state of an EARStatus.
+    Model of the state of something that is renderable using a symbol and colour.
+
+    Notes
+    -----
+    This class is used as the value in the the enumeration subclasses
+    :py:class:`EARStatus` and :py:class:`JobscriptElementState`.
+
     """
 
-    _value: int
-    #: Symbol to use when rendering a status.
+    #: ID that distinguishes the state.
+    id: int
+    #: Symbol to use when rendering a state.
     symbol: str
-    #: Colour to use when rendering a status.
+    #: Colour to use when rendering a state.
     colour: str
+    #: Documentation of the meaning of the state.
     __doc__: str = ""
 
 
-class EARStatus(_EARStatus, Enum):
+class _ReportableStateEnum(Enum):
+    """Enumeration superclass for reportable state subclasses with some shared methods."""
+
+    @property
+    def id(self) -> int:
+        """
+        The integer ID associated with this state.
+        """
+        return self.value.id
+
+    @property
+    def colour(self) -> str:
+        """
+        The colour associated with this state.
+        """
+        return self.value.colour
+
+    @property
+    def symbol(self) -> str:
+        """
+        The symbol associated with this state.
+        """
+        return self.value.symbol
+
+    @property
+    def rich_repr(self) -> str:
+        """
+        Rich representation of this enumeration element.
+        """
+        return f"[{self.colour}]{self.symbol}[/{self.colour}]"
+
+
+class EARStatus(_ReportableStateEnum):
     """Enumeration of all possible EAR statuses, and their associated status colour."""
 
     #: Not yet associated with a submission.
-    pending = (
+    pending = _ReportableStateData(
         0,
         ".",
         "grey46",
         "Not yet associated with a submission.",
     )
     #: Associated with a prepared submission that is not yet submitted.
-    prepared = (
+    prepared = _ReportableStateData(
         1,
         ".",
         "grey46",
         "Associated with a prepared submission that is not yet submitted.",
     )
     #: Submitted for execution.
-    submitted = (
+    submitted = _ReportableStateData(
         2,
         ".",
         "grey46",
         "Submitted for execution.",
     )
     #: Executing now.
-    running = (
+    running = _ReportableStateData(
         3,
         "●",
         "dodger_blue1",
@@ -72,7 +112,7 @@ class EARStatus(_EARStatus, Enum):
     )
     #: Not attempted due to a failure of an upstream action on which this depends,
     #: or a loop termination condition being satisfied.
-    skipped = (
+    skipped = _ReportableStateData(
         4,
         "s",
         "dark_orange",
@@ -82,31 +122,26 @@ class EARStatus(_EARStatus, Enum):
         ),
     )
     #: Aborted by the user; downstream actions will be attempted.
-    aborted = (
+    aborted = _ReportableStateData(
         5,
         "A",
         "deep_pink4",
         "Aborted by the user; downstream actions will be attempted.",
     )
     #: Probably exited successfully.
-    success = (
+    success = _ReportableStateData(
         6,
         "■",
         "green3",
         "Probably exited successfully.",
     )
     #: Probably failed.
-    error = (
+    error = _ReportableStateData(
         7,
         "E",
         "red3",
         "Probably failed.",
     )
-
-    @property
-    def value(self) -> int:
-        #: The value of the status.
-        return self._value
 
     @classmethod
     def get_non_running_submitted_states(cls) -> frozenset[EARStatus]:
@@ -119,13 +154,6 @@ class EARStatus(_EARStatus, Enum):
                 cls.error,
             }
         )
-
-    @property
-    def rich_repr(self) -> str:
-        """
-        The rich representation of the value.
-        """
-        return f"[{self.colour}]{self.symbol}[/{self.colour}]"
 
 
 class InputSourceType(Enum):

--- a/hpcflow/sdk/submission/enums.py
+++ b/hpcflow/sdk/submission/enums.py
@@ -6,81 +6,55 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-
-@dataclass(frozen=True)
-class _JES:
-    """
-    Model of the state of a JobscriptElementState
-    """
-
-    _value: int
-    #: The symbol used to render the state.
-    symbol: str
-    #: The colour used to render the state.
-    colour: str
-    __doc__: str = ""
+from hpcflow.sdk.core.enums import _ReportableStateData, _ReportableStateEnum
 
 
-class JobscriptElementState(_JES, Enum):
+class JobscriptElementState(_ReportableStateEnum):
     """Enumeration to convey a particular jobscript element state as reported by the
     scheduler."""
 
     #: Waiting for resource allocation.
-    pending = (
+    pending = _ReportableStateData(
         0,
         "○",
         "yellow",
         "Waiting for resource allocation.",
     )
     #: Waiting for one or more dependencies to finish.
-    waiting = (
+    waiting = _ReportableStateData(
         1,
         "◊",
         "grey46",
         "Waiting for one or more dependencies to finish.",
     )
     #: Executing now.
-    running = (
+    running = _ReportableStateData(
         2,
         "●",
         "dodger_blue1",
         "Executing now.",
     )
     #: Previously submitted but is no longer active.
-    finished = (
+    finished = _ReportableStateData(
         3,
         "■",
         "grey46",
         "Previously submitted but is no longer active.",
     )
     #: Cancelled by the user.
-    cancelled = (
+    cancelled = _ReportableStateData(
         4,
         "C",
         "red3",
         "Cancelled by the user.",
     )
     #: The scheduler reports an error state.
-    errored = (
+    errored = _ReportableStateData(
         5,
         "E",
         "red3",
         "The scheduler reports an error state.",
     )
-
-    @property
-    def value(self) -> int:
-        """
-        The numerical value of this state.
-        """
-        return self._value
-
-    @property
-    def rich_repr(self) -> str:
-        """
-        Rich representation of this enumeration element.
-        """
-        return f"[{self.colour}]{self.symbol}[/{self.colour}]"
 
 
 class SubmissionStatus(Enum):


### PR DESCRIPTION
A recent MyPy release (1.16) [doesn't seem to like](https://github.com/hpcflow/hpcflow-new/pull/837/checks) us overriding the `value` attribute in our `Enum` subclasses.