### PR TITLE
fix: make (demo) workflow return `isinstance` assertions

### DIFF
--- a/hpcflow/sdk/cli.py
+++ b/hpcflow/sdk/cli.py
@@ -189,7 +189,7 @@ def _make_API_CLI(app: BaseApp):
         format, or a YAML/JSON string.
 
         """
-        wk = app.make_workflow(
+        wk_or_sub = app.make_workflow(
             template_file_or_str=template_file_or_str,
             is_string=string,
             template_format=format,
@@ -203,8 +203,12 @@ def _make_API_CLI(app: BaseApp):
             status=status,
             add_submission=add_submission,
         )
-        assert isinstance(wk, Workflow)
-        click.echo(wk.path)
+        if add_submission:
+            assert isinstance(wk_or_sub, Submission)
+            click.echo(wk_or_sub.workflow.path)
+        else:
+            assert isinstance(wk_or_sub, Workflow)
+            click.echo(wk_or_sub.path)
 
     @click.command(name="go")
     @click.argument("template_file_or_str")

--- a/hpcflow/sdk/demo/cli.py
+++ b/hpcflow/sdk/demo/cli.py
@@ -29,6 +29,7 @@ from hpcflow.sdk.cli_common import (
     make_status_opt,
     add_sub_opt,
 )
+from hpcflow.sdk.submission.submission import Submission
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -133,7 +134,7 @@ def get_demo_workflow_CLI(app: BaseApp):
         status: bool = True,
         add_submission: bool = False,
     ):
-        wk = app.make_demo_workflow(
+        wk_or_sub = app.make_demo_workflow(
             workflow_name=workflow_name,
             template_format=format,
             path=path,
@@ -146,8 +147,12 @@ def get_demo_workflow_CLI(app: BaseApp):
             status=status,
             add_submission=add_submission,
         )
-        assert isinstance(wk, Workflow)
-        click.echo(wk.path)
+        if add_submission:
+            assert isinstance(wk_or_sub, Submission)
+            click.echo(wk_or_sub.workflow.path)
+        else:
+            assert isinstance(wk_or_sub, Workflow)
+            click.echo(wk_or_sub.path)
 
     @demo_workflow.command("go")
     @click.argument("workflow_name")

--- a/hpcflow/tests/unit/test_cli.py
+++ b/hpcflow/tests/unit/test_cli.py
@@ -146,7 +146,7 @@ def test_cli_click_exit_code_non_zero(tmp_path):
     assert error_file.is_file()
 
 
-def test_cli_make_demo_workflow(tmp_path):
+def test_cli_make_demo_workflow(new_null_config, tmp_path):
     """Check the demo workflow directory is generated."""
     runner = CliRunner()
     result = runner.invoke(
@@ -156,7 +156,7 @@ def test_cli_make_demo_workflow(tmp_path):
     assert Path(result.stdout_bytes.decode().strip()).is_dir()
 
 
-def test_cli_make_demo_workflow_add_sub(tmp_path):
+def test_cli_make_demo_workflow_add_sub(new_null_config, tmp_path):
     """Check the demo workflow directory is generated, and a submission is added."""
     runner = CliRunner()
     result = runner.invoke(

--- a/hpcflow/tests/unit/test_cli.py
+++ b/hpcflow/tests/unit/test_cli.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 
 from click.testing import CliRunner
@@ -143,3 +144,27 @@ def test_cli_click_exit_code_non_zero(tmp_path):
     )
     assert result.exit_code == 2
     assert error_file.is_file()
+
+
+def test_cli_make_demo_workflow(tmp_path):
+    """Check the demo workflow directory is generated."""
+    runner = CliRunner()
+    result = runner.invoke(
+        hf.cli, args=f'demo-workflow make workflow_1 --path "{str(tmp_path)}"'
+    )
+    assert result.exit_code == 0
+    assert Path(result.stdout_bytes.decode().strip()).is_dir()
+
+
+def test_cli_make_demo_workflow_add_sub(tmp_path):
+    """Check the demo workflow directory is generated, and a submission is added."""
+    runner = CliRunner()
+    result = runner.invoke(
+        hf.cli,
+        args=f'demo-workflow make workflow_1 --path "{str(tmp_path)}" --add-submission',
+    )
+    assert result.exit_code == 0
+    wk_path = Path(result.stdout_bytes.decode().strip())
+    assert wk_path.is_dir()
+    wk = hf.Workflow(wk_path)
+    assert len(wk.submissions) == 1


### PR DESCRIPTION
When using the CLI to make a (demo) workflow, the `--add-submission` option would result in `AssertionError`. Also, we now always print the generated workflow path, even if also adding a submission.