### PR TITLE
fix: saving empty arrays and large arrays

### DIFF
--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -18,7 +18,7 @@ from numpy.ma.core import MaskedArray
 import zarr  # type: ignore
 from zarr.errors import BoundsCheckError  # type: ignore
 from zarr.storage import DirectoryStore, FSStore  # type: ignore
-from zarr.util import guess_chunks
+from zarr.util import guess_chunks  # type: ignore
 from fsspec.implementations.zip import ZipFileSystem  # type: ignore
 from rich.console import Console
 from numcodecs import MsgPack, VLenArray, blosc, Blosc, Zstd  # type: ignore

--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -18,6 +18,7 @@ from numpy.ma.core import MaskedArray
 import zarr  # type: ignore
 from zarr.errors import BoundsCheckError  # type: ignore
 from zarr.storage import DirectoryStore, FSStore  # type: ignore
+from zarr.util import guess_chunks
 from fsspec.implementations.zip import ZipFileSystem  # type: ignore
 from rich.console import Console
 from numcodecs import MsgPack, VLenArray, blosc, Blosc, Zstd  # type: ignore
@@ -59,6 +60,7 @@ from hpcflow.sdk.submission.submission import (
     SUBMISSION_SUBMIT_TIME_KEYS,
 )
 from hpcflow.sdk.utils.arrays import get_2D_idx, split_arr
+from hpcflow.sdk.utils.patches import override_module_attrs
 from hpcflow.sdk.utils.strings import shorten_list_str
 
 if TYPE_CHECKING:
@@ -89,6 +91,11 @@ if TYPE_CHECKING:
 ListAny: TypeAlias = "list[Any]"
 #: Zarr attribute mapping context.
 ZarrAttrs: TypeAlias = "dict[str, Any]"
+#: Soft lower limit for the number of bytes in an array chunk
+_ARRAY_CHUNK_MIN: int = 500 * 1024 * 1024  # 500 MiB
+#: Hard upper limit for the number of bytes in an array chunk. Should be lower than the
+#: maximum buffer size of the blosc encoder, if we're using it (2 GiB)
+_ARRAY_CHUNK_MAX: int = 1024 * 1024 * 1024  # 1 GiB
 _JS: TypeAlias = "dict[str, list[dict[str, dict]]]"
 
 
@@ -124,8 +131,12 @@ def _encode_numpy_array(
     new_idx = (
         max((int(i.removeprefix("arr_")) for i in param_arr_group.keys()), default=-1) + 1
     )
-    if (chunk_shape := obj.shape)[0] == 0:
-        chunk_shape = tuple([1, *chunk_shape[1:]])
+    with override_module_attrs(
+        "zarr.util", {"CHUNK_MIN": _ARRAY_CHUNK_MIN, "CHUNK_MAX": _ARRAY_CHUNK_MAX}
+    ):
+        # `guess_chunks` also ensures chunk shape is at least 1 in each dimension:
+        chunk_shape = guess_chunks(obj.shape, obj.dtype.itemsize)
+
     param_arr_group.create_dataset(name=f"arr_{new_idx}", data=obj, chunks=chunk_shape)
     type_lookup["arrays"].append([path, new_idx])
 

--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -124,7 +124,9 @@ def _encode_numpy_array(
     new_idx = (
         max((int(i.removeprefix("arr_")) for i in param_arr_group.keys()), default=-1) + 1
     )
-    param_arr_group.create_dataset(name=f"arr_{new_idx}", data=obj, chunks=obj.shape)
+    if (chunk_shape := obj.shape)[0] == 0:
+        chunk_shape = tuple([1, *chunk_shape[1:]])
+    param_arr_group.create_dataset(name=f"arr_{new_idx}", data=obj, chunks=chunk_shape)
     type_lookup["arrays"].append([path, new_idx])
 
     return len(type_lookup["arrays"]) - 1

--- a/hpcflow/sdk/utils/patches.py
+++ b/hpcflow/sdk/utils/patches.py
@@ -1,4 +1,7 @@
+from contextlib import contextmanager
 from pathlib import Path
+import sys
+from typing import Any
 
 
 def resolve_path(path):
@@ -10,3 +13,19 @@ def resolve_path(path):
     """
     # TODO: this only seems to be used in a test; remove?
     return Path.cwd() / Path(path).resolve()  # cwd is ignored if already absolute
+
+
+@contextmanager
+def override_module_attrs(module_name: str, overrides: dict[str, Any]):
+    """Context manager to temporarily override module-level attributes. The module must be
+    imported (i.e. within `sys.modules`)."""
+
+    module = sys.modules[module_name]
+    original_values = {k: getattr(module, k) for k in overrides}
+    try:
+        for k, v in overrides.items():
+            setattr(module, k, v)
+        yield
+    finally:
+        for k, v in original_values.items():
+            setattr(module, k, v)

--- a/hpcflow/tests/unit/test_persistence.py
+++ b/hpcflow/tests/unit/test_persistence.py
@@ -576,3 +576,17 @@ def test_zarr_save_persistent_array_shape(null_config, tmp_path, array):
         path=tmp_path,
     )
     assert array.shape == wk.tasks[0].elements[0].get("inputs.p1")[:].shape
+
+
+def test_zarr_single_chunk_threshold(null_config, tmp_path):
+    # test very large arrays (> ~1 GB) are saved using multiple chunks
+    array = np.zeros(
+        268_435_456
+    )  # ~ 2.147483647 GB; greater than blosc's max buffer size
+    s1 = make_schemas(({"p1": None}, ()))
+    t1 = hf.Task(schema=s1, inputs={"p1": array})
+    wk = hf.Workflow.from_template_data(
+        template_name="test_large_array",
+        tasks=[t1],
+        path=tmp_path,
+    )

--- a/hpcflow/tests/unit/test_persistence.py
+++ b/hpcflow/tests/unit/test_persistence.py
@@ -6,7 +6,11 @@ from typing import cast, TYPE_CHECKING
 import numpy as np
 import zarr  # type: ignore
 import pytest
-from hpcflow.sdk.core.test_utils import make_test_data_YAML_workflow, make_workflow
+from hpcflow.sdk.core.test_utils import (
+    make_schemas,
+    make_test_data_YAML_workflow,
+    make_workflow,
+)
 from hpcflow.sdk.persistence.json import (
     JSONPersistentStore,
     JsonStoreElement,
@@ -551,3 +555,24 @@ def test_zarr_encode_decode_jobscript_block_dependencies_large_one_to_one():
     arr = ZarrPersistentStore._encode_jobscript_block_dependencies(deps_t)
     deps_rt = ZarrPersistentStore._decode_jobscript_block_dependencies(arr)
     assert deps_rt == deps
+
+
+@pytest.mark.parametrize(
+    "array",
+    (
+        np.array([]),
+        np.empty(0),
+        np.empty((0, 1, 2)),
+        np.array([1, 2, 3]),
+        np.array([[1, 2, 3], [4, 5, 6]]),
+    ),
+)
+def test_zarr_save_persistent_array_shape(null_config, tmp_path, array):
+    s1 = make_schemas(({"p1": None}, ()))
+    t1 = hf.Task(schema=s1, inputs={"p1": array})
+    wk = hf.Workflow.from_template_data(
+        template_name="test_save_empty_array",
+        tasks=[t1],
+        path=tmp_path,
+    )
+    assert array.shape == wk.tasks[0].elements[0].get("inputs.p1")[:].shape


### PR DESCRIPTION
This fixes a problem introduced by https://github.com/hpcflow/hpcflow-new/pull/829. Namely, empty arrays would have a chunk shape dimension of zero, which is not allowed by Zarr. The initial fix ensures that the outer dimension of the chunk shape is at least one.

Another problem with #829 was then brought to my attention (the default chunk encoder we use, `blosc`, has a maximum buffer size, which we bust when trying to save big arrays to a single chunk). This is also fixed here by using Zarr's function for guessing chunk size, but also setting some limits for the size so for small arrays we still generate only one chunk.