### PR TITLE
Use correct operator to test filesystem protocol

### DIFF
--- a/hpcflow/sdk/core/workflow.py
+++ b/hpcflow/sdk/core/workflow.py
@@ -892,7 +892,7 @@ class Workflow(AppAware):
         if self._store.fs:
             if self._store.fs.protocol == "zip":
                 return self._store.fs.of.path
-            elif self._store.fs.protocol == ("file", "local"):
+            elif self._store.fs.protocol in ("file", "local"):
                 return self.path
         raise NotImplementedError("Only (local) zip and local URLs provided for now.")
 


### PR DESCRIPTION
The protocol is a string (at least on this system) and equal to `file` (at least here); we want to test if it's in a collection, not to see if it is equal to the collection...