### PR TITLE
Fix submission get-known --json

### DIFF
--- a/hpcflow/sdk/cli.py
+++ b/hpcflow/sdk/cli.py
@@ -4,6 +4,7 @@ Command line interface implementation.
 
 from __future__ import annotations
 import contextlib
+import datetime
 import json
 import os
 import time
@@ -772,6 +773,12 @@ def _make_submission_CLI(app: BaseApp):
     def get_login_nodes(scheduler: SGEPosix):
         pprint(scheduler.get_login_nodes())
 
+    class _DateTimeJSONEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, datetime.datetime):
+                return obj.isoformat()
+            return super().default(obj)
+
     @submission.command()
     @click.option(
         "as_json",
@@ -784,7 +791,7 @@ def _make_submission_CLI(app: BaseApp):
         """Print known-submissions information as a formatted Python object."""
         out = app.get_known_submissions(as_json=as_json)
         if as_json:
-            click.echo(json.dumps(out))
+            click.echo(json.dumps(out, cls=_DateTimeJSONEncoder))
         else:
             pprint(out)
 


### PR DESCRIPTION
`datetime` objects aren't serializable by default by `json.dumps()`; this fixes that.

----

The problem occurred when doing:

```bash
hpcflow submission get-known --json
```

With a long trace ending in:
```
  File "C:\Users\ZZALSDKF\git\hpcflow-new\hpcflow\sdk\cli.py", line 787, in get_known
    click.echo(json.dumps(out))
               ^^^^^^^^^^^^^^^
  File "C:\Users\ZZALSDKF\git\hpcflow-new\.conda\Lib\json\__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ZZALSDKF\git\hpcflow-new\.conda\Lib\json\encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\ZZALSDKF\git\hpcflow-new\.conda\Lib\json\encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "C:\Users\ZZALSDKF\git\hpcflow-new\.conda\Lib\json\encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```
The problem is that `datetime` objects aren't serializable as JSON by default; it needs a little interceptor to fix that.

I'm rendering the `datetime` object using the ISO time format. That's widely supported.