### PR TITLE
fix: waiting on WSL jobscripts

### DIFF
--- a/hpcflow/sdk/submission/shells/bash.py
+++ b/hpcflow/sdk/submission/shells/bash.py
@@ -405,8 +405,10 @@ class WSLBash(Bash):
         # `Start-Process` (see `Jobscript._launch_direct_js_win`) seems to resolve the
         # executable, which means the process's `cmdline` might look different to what we
         # record; so let's resolve the WSL executable ourselves:
+        resolved_exec = shutil.which(WSL_executable or self.DEFAULT_WSL_EXE)
+        assert resolved_exec
         #: The WSL executable wrapper.
-        self.WSL_executable = shutil.which(WSL_executable or self.DEFAULT_WSL_EXE)
+        self.WSL_executable = resolved_exec
         #: The WSL distribution to use, if any.
         self.WSL_distribution = WSL_distribution
         #: The WSL user to use, if any.

--- a/hpcflow/sdk/submission/shells/bash.py
+++ b/hpcflow/sdk/submission/shells/bash.py
@@ -5,6 +5,7 @@ Shell models based on the GNU Bourne-Again Shell.
 from __future__ import annotations
 from pathlib import Path
 import subprocess
+import shutil
 from textwrap import dedent, indent
 from typing import TYPE_CHECKING
 from typing_extensions import override
@@ -335,7 +336,7 @@ class WSLBash(Bash):
     """
 
     #: Default name of the WSL interface executable.
-    DEFAULT_WSL_EXE: ClassVar[str] = "wsl"
+    DEFAULT_WSL_EXE: ClassVar[str] = "wsl.exe"
 
     #: Template for the jobscript functions file.
     JS_FUNCS: ClassVar[str] = dedent(
@@ -400,8 +401,12 @@ class WSLBash(Bash):
         *args,
         **kwargs,
     ):
+
+        # `Start-Process` (see `Jobscript._launch_direct_js_win`) seems to resolve the
+        # executable, which means the process's `cmdline` might look different to what we
+        # record; so let's resolve the WSL executable ourselves:
         #: The WSL executable wrapper.
-        self.WSL_executable = WSL_executable or self.DEFAULT_WSL_EXE
+        self.WSL_executable = shutil.which(WSL_executable or self.DEFAULT_WSL_EXE)
         #: The WSL distribution to use, if any.
         self.WSL_distribution = WSL_distribution
         #: The WSL user to use, if any.

--- a/hpcflow/tests/shells/wsl/test_wsl_submission.py
+++ b/hpcflow/tests/shells/wsl/test_wsl_submission.py
@@ -9,14 +9,6 @@ from hpcflow.sdk.core.test_utils import make_test_data_YAML_workflow
 def test_workflow_1(tmp_path: Path, null_config):
     wk = make_test_data_YAML_workflow("workflow_1_wsl.yaml", path=tmp_path)
     wk.submit(wait=True, add_to_known=False)
-    time.sleep(20)  # TODO: bug! for some reason the new parameter isn't actually written
-    # to disk when using WSL until several seconds after the workflow has finished!
-    # this is probably because the NTFS filesystem is "sync'd" via polling in this case?
-    # so changes made on the NTFS files by WSL are not immediate on the Windows side.
-    # perhaps when we re-wire the wait command, we could add an option to wait on a
-    # parameter being set, which could watch the relevant chunk file for changes?
-
-    # ACTUALLY: I think wait is not working here at all for WSL... it's returning early!
     p2 = wk.tasks[0].elements[0].outputs.p2
     assert isinstance(p2, hf.ElementParameter)
     assert p2.value == "201"


### PR DESCRIPTION
Currently, when using `resources -> shell: wsl`, we run both the jobscript and commands files in WSL*. The WSL jobscript is launched via the direct windows launcher (via a `powershell.exe ... Start-Process ...` command), since the `wsl.exe` command is a windows command. As previously discovered, `Start-Process` resolves the executable, so `wsl.exe` will typically become `C:\\WINDOWS\\system32\\wsl.exe`. When using the `wait` command, there is then a mismatch between the process command line we recorded (`wsl.exe`) and that recorded by the process (the resolved path). This PR fixes this by resolving the full path to the `WSL_executable` in the `WSLBash` initialiser.

*This may change in future because we could instead use a powershell jobscript with WSL commands files, which would reduce the number of jobscripts required.