### PR TITLE
Fix logging issues

### DIFF
--- a/hpcflow/sdk/__init__.py
+++ b/hpcflow/sdk/__init__.py
@@ -134,7 +134,7 @@ def get_SDK_logger(name: str | None = None) -> logging.Logger:
 def _init_logger() -> None:
     level = os.environ.get("HPCFLOW_SDK_CONSOLE_LOG_LEVEL", "ERROR")
     SDK_logger = get_SDK_logger()
-    SDK_logger.setLevel("DEBUG")
+    SDK_logger.setLevel(level)
 
     sh = logging.StreamHandler()
     sh.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))

--- a/hpcflow/sdk/log.py
+++ b/hpcflow/sdk/log.py
@@ -202,12 +202,26 @@ class AppLog:
         self._app = app
         #: The base logger for the application.
         self.logger = logging.getLogger(app.package_name)
-        self.logger.setLevel(logging.DEBUG)
+        self.logger.setLevel(logging.WARNING)
         #: The handler for directing logging messages to the console.
         self.console_handler = self.__add_console_logger(
             level=log_console_level or AppLog.DEFAULT_LOG_CONSOLE_LEVEL
         )
         self.file_handler: logging.FileHandler | None = None
+
+    def _ensure_logger_level(self):
+        """Ensure the logger's level is set to a level that triggers the handlers.
+
+        Notes
+        -----
+        Previously, we fixed the logger to DEBUG, but we found other Python packages
+        could then trigger debug logs in hpcflow even though the handlers were set to e.g.
+        ERROR.
+
+        """
+        min_level = min((handler.level for handler in self.logger.handlers), default=0)
+        if self.logger.level != min_level:
+            self.logger.setLevel(min_level)
 
     def __add_console_logger(self, level: str, fmt: str | None = None) -> logging.Handler:
         fmt = fmt or "%(levelname)s %(name)s: %(message)s"
@@ -215,6 +229,7 @@ class AppLog:
         handler.setFormatter(logging.Formatter(fmt))
         handler.setLevel(level)
         self.logger.addHandler(handler)
+        self._ensure_logger_level()
         return handler
 
     def update_console_level(self, new_level: str | None = None) -> None:
@@ -223,11 +238,13 @@ class AppLog:
         """
         new_level = new_level or AppLog.DEFAULT_LOG_CONSOLE_LEVEL
         self.console_handler.setLevel(new_level.upper())
+        self._ensure_logger_level()
 
     def update_file_level(self, new_level: str | None = None) -> None:
         if self.file_handler:
             new_level = new_level or AppLog.DEFAULT_LOG_FILE_LEVEL
             self.file_handler.setLevel(new_level.upper())
+            self._ensure_logger_level()
 
     def add_file_logger(
         self,
@@ -253,6 +270,7 @@ class AppLog:
         handler.setLevel(level.upper())
         self.logger.addHandler(handler)
         self.file_handler = handler
+        self._ensure_logger_level()
 
     def remove_file_handler(self) -> None:
         """Remove the file handler."""
@@ -262,3 +280,4 @@ class AppLog:
             )
             self.logger.removeHandler(self.file_handler)
             self.file_handler = None
+            self._ensure_logger_level()

--- a/hpcflow/sdk/log.py
+++ b/hpcflow/sdk/log.py
@@ -252,6 +252,7 @@ class AppLog:
         level: str | None = None,
         fmt: str | None = None,
         max_bytes: int | None = None,
+        backup_count: int = 4,
     ) -> None:
         """
         Add a log file.
@@ -259,13 +260,17 @@ class AppLog:
         path = Path(path)
         fmt = fmt or "%(asctime)s %(levelname)s %(name)s: %(message)s"
         level = level or AppLog.DEFAULT_LOG_FILE_LEVEL
-        max_bytes = max_bytes or int(10e6)
+        max_bytes = max_bytes or int(50e6)
 
         if not path.parent.is_dir():
             self.logger.info(f"Generating log file parent directory: {path.parent!r}")
             path.parent.mkdir(exist_ok=True, parents=True)
 
-        handler = logging.handlers.RotatingFileHandler(filename=path, maxBytes=max_bytes)
+        handler = logging.handlers.RotatingFileHandler(
+            filename=path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+        )
         handler.setFormatter(logging.Formatter(fmt))
         handler.setLevel(level.upper())
         self.logger.addHandler(handler)


### PR DESCRIPTION
We now set the app log level to the minimum of its handlers' levels, rather than fixing it to `debug`. Previously, we were seeing hpcflow `debug` log emissions even when the respective handler levels were higher (e.g. `error`), when some third party Python packages were loaded (e.g. PyMC and PyVista). I'm not entirely sure what was happening but this fix ensures that by default we don't see that behaviour anymore (handlers, and so now also the log itself, are set to `warning` by default).

We also change the SDK logger level to `error` by default instead of `debug`.

Finally, this includes a fix for the rotating file log handler; it was missing the `backupCount` argument which meant it never rolled over.