### PR TITLE
Support an optional default value for testing rules

### DIFF
--- a/hpcflow/sdk/core/actions.py
+++ b/hpcflow/sdk/core/actions.py
@@ -1803,6 +1803,8 @@ class ActionRule(JSONLike):
         The name of a class to cast the attribute to before checking.
     doc: str
         Documentation for this rule, if any.
+    default: bool
+        Optional default value to return when testing the rule if the path is not valid.
     """
 
     _child_objects: ClassVar[tuple[ChildObjectSpec, ...]] = (
@@ -1818,6 +1820,7 @@ class ActionRule(JSONLike):
         condition: dict[str, Any] | ConditionLike | None = None,
         cast: str | None = None,
         doc: str | None = None,
+        default: bool | None = None,
     ):
         if rule is None:
             #: The rule to apply.
@@ -1828,10 +1831,11 @@ class ActionRule(JSONLike):
                 condition=condition,
                 cast=cast,
                 doc=doc,
+                default=default,
             )
         elif any(
             arg is not None
-            for arg in (check_exists, check_missing, path, condition, cast, doc)
+            for arg in (check_exists, check_missing, path, condition, cast, doc, default)
         ):
             raise TypeError(
                 f"{self.__class__.__name__} `rule` specified in addition to rule "

--- a/hpcflow/sdk/core/rule.py
+++ b/hpcflow/sdk/core/rule.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from valida.conditions import ConditionLike  # type: ignore
 from valida import Rule as ValidaRule  # type: ignore
 
+from hpcflow.sdk.core.errors import ContainerKeyError, UnsetParameterDataError
 from hpcflow.sdk.core.json_like import JSONLike
 from hpcflow.sdk.core.utils import get_in_container
 from hpcflow.sdk.log import TimeIt
@@ -40,6 +41,8 @@ class Rule(JSONLike):
         If set, a cast to apply prior to running the general check.
     doc: str
         Optional descriptive text.
+    default: bool
+        Optional default value to return when testing the rule if the path is not valid.
     """
 
     def __init__(
@@ -50,6 +53,7 @@ class Rule(JSONLike):
         condition: dict[str, Any] | ConditionLike | None = None,
         cast: str | None = None,
         doc: str | None = None,
+        default: bool | None = None,
     ):
         if sum(arg is not None for arg in (check_exists, check_missing, condition)) != 1:
             raise ValueError(
@@ -73,6 +77,8 @@ class Rule(JSONLike):
         self.cast = cast
         #: Optional descriptive text.
         self.doc = doc
+        #: A default value to return from testing the rule if the path is not valid.
+        self.default = default
 
     def __repr__(self) -> str:
         out = f"{self.__class__.__name__}("
@@ -86,6 +92,8 @@ class Rule(JSONLike):
                 out += f", path={self.path!r}"
             if self.cast:
                 out += f", cast={self.cast!r}"
+            if self.default is not None:
+                out += f", default={self.default!r}"
 
         out += ")"
         return out
@@ -100,6 +108,7 @@ class Rule(JSONLike):
             and self.condition == other.condition
             and self.cast == other.cast
             and self.doc == other.doc
+            and self.default == other.default
         )
 
     @classmethod
@@ -144,15 +153,27 @@ class Rule(JSONLike):
                     elem_res = element_like.get_resources()
 
                 res_path = self.path.split(".")[1:]
-                element_dat = get_in_container(
-                    cont=elem_res, path=res_path, cast_indices=True
-                )
+                try:
+                    element_dat = get_in_container(
+                        cont=elem_res, path=res_path, cast_indices=True
+                    )
+                except ContainerKeyError:
+                    if self.default is not None:
+                        return bool(self.default)
+                    else:
+                        raise
             else:
-                element_dat = element_like.get(
-                    self.path,
-                    raise_on_missing=True,
-                    raise_on_unset=True,
-                )
+                try:
+                    element_dat = element_like.get(
+                        self.path,
+                        raise_on_missing=True,
+                        raise_on_unset=True,
+                    )
+                except (ValueError, IndexError, UnsetParameterDataError):
+                    if self.default is not None:
+                        return bool(self.default)
+                    else:
+                        raise
             # test the rule:
             return self._valida_check(element_dat)
 

--- a/hpcflow/sdk/core/types.py
+++ b/hpcflow/sdk/core/types.py
@@ -229,6 +229,8 @@ class RuleArgs(TypedDict):
     cast: NotRequired[str]
     #: Optional descriptive text.
     doc: NotRequired[str]
+    #: A default value to return from testing the rule if the path is not valid.
+    default: NotRequired[bool]
 
 
 class ActParameterDependence(TypedDict):


### PR DESCRIPTION
If the location described by the rule's path is invalid, this default will be returned when testing the rule.