### PR TITLE
Support app-defined parameter encoders/decoders

### DIFF
--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -486,6 +486,12 @@ class BaseApp(metaclass=Singleton):
         `module` argument and `hf` is the `docs_import_conv` argument.
     docs_url:
         URL to documentation.
+    encoders:
+        callable that takes no arguments and returns a mapping between string store types
+        (e.g. "zarr", "json") and a dictionary of additional parameter encoders.
+    decoders:
+        callable that takes no arguments and returns a mapping between string store types
+        (e.g. "zarr", "json") and a dictionary of additional parameter decoders.
     """
 
     _known_subs_file_name: ClassVar = "known_submissions.txt"
@@ -513,6 +519,8 @@ class BaseApp(metaclass=Singleton):
         package_name: str | None = None,
         docs_import_conv: str | None = None,
         docs_url: str | None = None,
+        encoders: Callable | None = None,
+        decoders: Callable | None = None,
     ):
         SDK_logger.info(f"Generating {self.__class__.__name__} {name!r}.")
 
@@ -550,6 +558,10 @@ class BaseApp(metaclass=Singleton):
         self.docs_import_conv = docs_import_conv
         #: URL to documentation.
         self.docs_url = docs_url
+        #: Callable that returns additional parameter encoders.
+        self.encoders = encoders or (lambda: {})
+        #: Callable that returns additional parameter decoders.
+        self.decoders = decoders or (lambda: {})
 
         #: Command line interface subsystem.
         self.cli = make_cli(self)
@@ -3685,15 +3697,15 @@ class BaseApp(metaclass=Singleton):
 
         columns: tuple[str, ...]
         if full:
-            columns = ("id", "name", "status", "times", "actions")
+            columns = ("id", "name", "status", "actions")
         else:
             columns = (
                 "id",
                 "name",
                 "status",
-                "submit_time",
-                "start_time",
-                "end_time",
+                # "submit_time",
+                # "start_time",
+                # "end_time",
                 "actions_compact",
             )
 

--- a/hpcflow/sdk/core/parameters.py
+++ b/hpcflow/sdk/core/parameters.py
@@ -15,7 +15,6 @@ from typing_extensions import override, TypeIs
 import warnings
 
 import numpy as np
-from scipy.stats.qmc import LatinHypercube, scale
 from valida import Schema as ValidaSchema  # type: ignore
 
 from hpcflow.sdk.typing import hydrate
@@ -1667,6 +1666,8 @@ class MultiPathSequence(_BaseSequence):
         optimization: Literal["random-cd", "lloyd"] | None = None,
         rng=None,
     ) -> NDArray:
+
+        from scipy.stats.qmc import LatinHypercube, scale
 
         num_paths = len(paths)
         kwargs = dict(

--- a/hpcflow/sdk/persistence/base.py
+++ b/hpcflow/sdk/persistence/base.py
@@ -6,6 +6,7 @@ Store* classes represent the element-metadata in the store, in a store-agnostic 
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from collections import defaultdict
 import contextlib
 import copy
 from dataclasses import dataclass, field
@@ -716,16 +717,6 @@ class StoreParameter:
 
         return isinstance(value, PV)
 
-    def _init_type_lookup(self) -> TypeLookup:
-        return cast(
-            "TypeLookup",
-            {
-                "tuples": [],
-                "sets": [],
-                **{k: [] for k in self._decoders},
-            },
-        )
-
     def _encode(
         self,
         obj: ParameterTypes,
@@ -737,7 +728,7 @@ class StoreParameter:
 
         path = path or []
         if type_lookup is None:
-            type_lookup = self._init_type_lookup()
+            type_lookup = cast(TypeLookup, defaultdict(list))
 
         if len(path) > self._MAX_DEPTH:
             raise RuntimeError("I'm in too deep!")
@@ -843,25 +834,30 @@ class StoreParameter:
 
         obj = get_in_container(data_["data"], path)
 
-        for tuple_path in data_["type_lookup"]["tuples"]:
-            try:
-                rel_path = get_relative_path(tuple_path, path)
-            except ValueError:
-                continue
-            if rel_path:
-                set_in_container(obj, rel_path, tuple(get_in_container(obj, rel_path)))
-            else:
-                obj = tuple(obj)
-
-        for set_path in data_["type_lookup"]["sets"]:
-            try:
-                rel_path = get_relative_path(set_path, path)
-            except ValueError:
-                continue
-            if rel_path:
-                set_in_container(obj, rel_path, set(get_in_container(obj, rel_path)))
-            else:
-                obj = set(obj)
+        for type_, paths in data_["type_lookup"].items():
+            for type_path in paths:
+                if type_ == "tuples":
+                    try:
+                        rel_path = get_relative_path(type_path, path)
+                    except ValueError:
+                        continue
+                    if rel_path:
+                        set_in_container(
+                            obj, rel_path, tuple(get_in_container(obj, rel_path))
+                        )
+                    else:
+                        obj = tuple(obj)
+                elif type_ == "sets":
+                    try:
+                        rel_path = get_relative_path(type_path, path)
+                    except ValueError:
+                        continue
+                    if rel_path:
+                        set_in_container(
+                            obj, rel_path, set(get_in_container(obj, rel_path))
+                        )
+                    else:
+                        obj = set(obj)
 
         for data_type in cls._decoders:
             obj = cls._decoders[data_type](

--- a/hpcflow/sdk/persistence/base.py
+++ b/hpcflow/sdk/persistence/base.py
@@ -700,6 +700,9 @@ class StoreParameter:
     _decoders: ClassVar[dict[str, Callable]] = {}
     _MAX_DEPTH: ClassVar[int] = 50
 
+    _all_encoders: ClassVar[dict[type, Callable]] = {}
+    _all_decoders: ClassVar[dict[type, Callable]] = {}
+
     def encode(self, **kwargs) -> dict[str, Any] | int:
         """Prepare store parameter data for the persistent store."""
         if self.is_set:
@@ -728,7 +731,7 @@ class StoreParameter:
 
         path = path or []
         if type_lookup is None:
-            type_lookup = cast(TypeLookup, defaultdict(list))
+            type_lookup = cast("TypeLookup", defaultdict(list))
 
         if len(path) > self._MAX_DEPTH:
             raise RuntimeError("I'm in too deep!")
@@ -778,12 +781,13 @@ class StoreParameter:
         elif isinstance(obj, PRIMITIVES):
             data = obj
 
-        elif type(obj) in self._encoders:
+        elif type(obj) in self._all_encoders:
             assert type_lookup is not None
-            data = self._encoders[type(obj)](
+            data = self._all_encoders[type(obj)](
                 obj=obj,
                 path=path,
                 type_lookup=type_lookup,
+                root_encoder=self._encode,
                 **kwargs,
             )
 
@@ -859,8 +863,8 @@ class StoreParameter:
                     else:
                         obj = set(obj)
 
-        for data_type in cls._decoders:
-            obj = cls._decoders[data_type](
+        for data_type in cls._all_decoders:
+            obj = cls._all_decoders[data_type](
                 obj=obj,
                 type_lookup=data_["type_lookup"],
                 path=path,
@@ -995,6 +999,26 @@ class PersistentStore(
         self._reset_cache()
 
         self._use_parameters_metadata_cache: bool = False  # subclass-specific cache
+
+    def _ensure_all_encoders(self):
+        """Ensure app-defined encoders are included in the StoreParameter's encoders
+        map."""
+        param_cls = self._store_param_cls()
+        if not param_cls._all_encoders:
+            param_cls._all_encoders = {
+                **param_cls._encoders,
+                **self.workflow._app.encoders().get(self._name, {}),
+            }
+
+    def _ensure_all_decoders(self):
+        """Ensure app-defined decoders are included in the StoreParameter's encoders
+        map."""
+        param_cls = self._store_param_cls()
+        if not param_cls._all_decoders:
+            param_cls._all_decoders = {
+                **param_cls._decoders,
+                **self.workflow._app.decoders().get(self._name, {}),
+            }
 
     @abstractmethod
     def cached_load(self) -> contextlib.AbstractContextManager[None]:

--- a/hpcflow/sdk/persistence/json.py
+++ b/hpcflow/sdk/persistence/json.py
@@ -583,6 +583,7 @@ class JSONPersistentStore(
                     )
 
     def _append_parameters(self, params: Sequence[StoreParameter]):
+        self._ensure_all_encoders()
         with self.using_resource("parameters", "update") as params_u:
             for param_i in params:
                 params_u["data"][str(param_i.id_)] = param_i.encode()
@@ -590,6 +591,7 @@ class JSONPersistentStore(
 
     def _set_parameter_values(self, set_parameters: dict[int, tuple[Any, bool]]):
         """Set multiple unset persistent parameters."""
+        self._ensure_all_encoders()
         param_objs = self._get_persistent_parameters(set_parameters)
         with self.using_resource("parameters", "update") as params:
             for param_id, (value, is_file) in set_parameters.items():
@@ -831,6 +833,7 @@ class JSONPersistentStore(
     def _get_persistent_parameters(
         self, id_lst: Iterable[int], **kwargs
     ) -> Mapping[int, StoreParameter]:
+        self._ensure_all_decoders()
         params, id_lst_ = self._get_cached_persistent_parameters(id_lst)
         if id_lst_:
             with self.using_resource("parameters", "read") as params_:

--- a/hpcflow/sdk/persistence/types.py
+++ b/hpcflow/sdk/persistence/types.py
@@ -3,7 +3,7 @@ Types used in type-checking the persistence subsystem.
 """
 
 from __future__ import annotations
-from typing import Any, Generic, TypeVar, TYPE_CHECKING
+from typing import Any, Generic, TypeVar, TYPE_CHECKING, DefaultDict
 from typing_extensions import TypedDict, NotRequired, TypeAlias
 
 if TYPE_CHECKING:
@@ -238,23 +238,8 @@ class Metadata(TypedDict):
     ts_name_fmt: NotRequired[str]
 
 
-class TypeLookup(TypedDict, total=False):
-    """
-    Information for looking up the type of a parameter.
-
-    Note
-    ----
-    Not a total typed dictionary.
-    """
-
-    #: Tuples involving the parameter.
-    tuples: list[list[int]]
-    #: Sets involving the parameter.
-    sets: list[list[int]]
-    #: Arrays involving the parameter.
-    arrays: list[list[list[int] | int]]
-    #: Masked arrays involving the parameter.
-    masked_arrays: list[list[int | list[int]]]
+#: Information for looking up the type of a parameter.
+TypeLookup = DefaultDict[str, list[list]]
 
 
 class EncodedStoreParameter(TypedDict):

--- a/hpcflow/sdk/persistence/zarr.py
+++ b/hpcflow/sdk/persistence/zarr.py
@@ -125,6 +125,7 @@ def _encode_numpy_array(
     path: list[int],
     root_group: Group,
     arr_path: list[int],
+    root_encoder: Callable,
 ) -> int:
     # Might need to generate new group:
     param_arr_group = root_group.require_group(arr_path)
@@ -177,10 +178,13 @@ def _encode_masked_array(
     path: list[int],
     root_group: Group,
     arr_path: list[int],
+    root_encoder: Callable,
 ):
-    data_idx = _encode_numpy_array(obj.data, type_lookup, path, root_group, arr_path)
+    data_idx = _encode_numpy_array(
+        obj.data, type_lookup, path, root_group, arr_path, root_encoder
+    )
     mask_idx = _encode_numpy_array(
-        cast("NDArray", obj.mask), type_lookup, path, root_group, arr_path
+        cast("NDArray", obj.mask), type_lookup, path, root_group, arr_path, root_encoder
     )
     type_lookup["masked_arrays"].append([path, [data_idx, mask_idx]])
 
@@ -1298,6 +1302,7 @@ class ZarrPersistentStore(
 
     def _append_parameters(self, params: Sequence[StoreParameter]):
         """Add new persistent parameters."""
+        self._ensure_all_encoders()
         base_arr = self._get_parameter_base_array(mode="r+", write_empty_chunks=False)
         src_arr = self._get_parameter_sources_array(mode="r+")
         self.logger.debug(
@@ -1323,7 +1328,7 @@ class ZarrPersistentStore(
 
     def _set_parameter_values(self, set_parameters: dict[int, tuple[Any, bool]]):
         """Set multiple unset persistent parameters."""
-
+        self._ensure_all_encoders()
         param_ids = list(set_parameters)
         # the `decode` call in `_get_persistent_parameters` should be quick:
         params = self._get_persistent_parameters(param_ids)
@@ -1759,6 +1764,7 @@ class ZarrPersistentStore(
     def _get_persistent_parameters(
         self, id_lst: Iterable[int], *, dataset_copy: bool = False, **kwargs
     ) -> dict[int, ZarrStoreParameter]:
+        self._ensure_all_decoders()
         params, id_lst = self._get_cached_persistent_parameters(id_lst)
         if id_lst:
 

--- a/hpcflow/tests/unit/test_persistence.py
+++ b/hpcflow/tests/unit/test_persistence.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from pathlib import Path
 import sys
-from typing import Any, Dict, List, Tuple
-from typing import cast, TYPE_CHECKING
+
+from typing import Any, cast, TYPE_CHECKING
 import numpy as np
 import zarr  # type: ignore
 import pytest
@@ -18,6 +18,7 @@ from hpcflow.sdk.persistence.json import (
     JsonStoreEAR,
 )
 from hpcflow.sdk.persistence.zarr import ZarrPersistentStore
+from hpcflow.sdk.core.parameters import NullDefault
 
 from hpcflow.app import app as hf
 
@@ -590,3 +591,62 @@ def test_zarr_single_chunk_threshold(null_config, tmp_path):
         tasks=[t1],
         path=tmp_path,
     )
+
+
+@pytest.mark.parametrize("store", ["json", "zarr"])
+def test_store_parameter_encode_decode_types(null_config, tmp_path, store):
+
+    (s1,) = make_schemas(
+        (
+            {
+                "p1": NullDefault.NULL,
+                "p2": NullDefault.NULL,
+                "p3": NullDefault.NULL,
+                "p4": NullDefault.NULL,
+                "p5": NullDefault.NULL,
+                "p6": NullDefault.NULL,
+                "p7": NullDefault.NULL,
+            },
+            tuple(),
+        ),
+    )
+
+    p1 = [1, 2, 3]
+    p2 = (1, 2, 3)
+    p3 = {1, 2, 3}
+    p4 = None
+    p5 = np.arange(10)
+    p6 = np.ma.array(np.arange(10), mask=np.random.randint(0, 2, 10))
+    p7 = [[1, 2], (3, 4), {5, 6}]
+
+    t1 = hf.Task(
+        schema=s1,
+        inputs={
+            "p1": p1,
+            "p2": p2,
+            "p3": p3,
+            "p4": p4,
+            "p5": p5 if store == "zarr" else None,
+            "p6": p6 if store == "zarr" else None,
+            "p7": p7,
+        },
+    )
+
+    wk = hf.Workflow.from_template_data(
+        template_name="test_store_encoders",
+        overwrite=True,
+        name_use_dir=False,
+        name_add_timestamp=False,
+        tasks=[t1],
+        store="zarr",
+    )
+
+    assert wk.tasks[0].elements[0].get("inputs.p1") == p1
+    assert wk.tasks[0].elements[0].get("inputs.p2") == p2
+    assert wk.tasks[0].elements[0].get("inputs.p3") == p3
+    assert wk.tasks[0].elements[0].get("inputs.p4") == p4
+    assert wk.tasks[0].elements[0].get("inputs.p7") == p7
+
+    if store == "zarr":
+        assert np.allclose(wk.tasks[0].elements[0].get("inputs.p5"), p5)
+        assert np.allclose(wk.tasks[0].elements[0].get("inputs.p6"), p6)

--- a/hpcflow/tests/unit/test_persistence.py
+++ b/hpcflow/tests/unit/test_persistence.py
@@ -634,11 +634,9 @@ def test_store_parameter_encode_decode_types(null_config, tmp_path, store):
 
     wk = hf.Workflow.from_template_data(
         template_name="test_store_encoders",
-        overwrite=True,
-        name_use_dir=False,
-        name_add_timestamp=False,
         tasks=[t1],
-        store="zarr",
+        store=store,
+        path=tmp_path,
     )
 
     assert wk.tasks[0].elements[0].get("inputs.p1") == p1


### PR DESCRIPTION
This enables downstream apps (e.g. MatFlow) to define custom parameter encoders and decoders.