### PR TITLE
Update default config dir to `~/.hpcflow`

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,7 +28,7 @@
     The recommended way to install {{ app_name }} is to
     use pip to install the Python package from PyPI::
 
-      pip install {{ dist_name }}
+      pip install --pre {{ dist_name }}
 
     This installs the python package, which also gives the CLI version of {{ app_name }}.
 

--- a/docs/source/user/tutorials/install-locally.rst
+++ b/docs/source/user/tutorials/install-locally.rst
@@ -42,7 +42,7 @@
   ==============================
 
   Once you have created and activated a Python environment (check for the environment name in brackets in your prompt), you can install {{ app_name }} using pip by running
-  ``pip install {{ dist_name }}``.
+  ``pip install --pre {{ dist_name }}``.
 
   This will install the latest version of {{ app_name }} from the Python Package Index (PyPI), and all the dependencies it needs.
   Once it has finished, check that {{ app_name }} has been installed correctly by running

--- a/hpcflow/app.py
+++ b/hpcflow/app.py
@@ -14,7 +14,7 @@ __dir__ = sdk_app.get_app_module_dir()
 # set app-level config options:
 config_options = ConfigOptions(
     directory_env_var="HPCFLOW_CONFIG_DIR",
-    default_directory="~/.hpcflow-new",
+    default_directory="~/.hpcflow",
 )
 
 # load built in template components (in this case, for demonstration purposes):

--- a/hpcflow/sdk/config/config_file.py
+++ b/hpcflow/sdk/config/config_file.py
@@ -26,6 +26,7 @@ from hpcflow.sdk.config.errors import (
     ConfigFileValidationError,
     ConfigInvocationKeyNotFoundError,
     ConfigValidationError,
+    IncompatibleConfigError,
 )
 
 if TYPE_CHECKING:
@@ -377,6 +378,23 @@ class ConfigFile:
             data = yaml.load(handle)
             handle.seek(0)
             data_rt = yaml_rt.load(handle)
+
+        # stop if it looks like the config file is from a very old version of hpcflow (or
+        # MatFlow):
+        if self.directory.joinpath("profiles").is_dir():
+            raise IncompatibleConfigError(
+                f"Found a `profiles` directory in the config directory: "
+                f"{self.directory!r}, which indicates the directory was created by a "
+                f"very old version (<= 0.1.16) of hpcflow. Please rename or delete this "
+                f"directory."
+            )
+        elif "software_sources" in data:
+            raise IncompatibleConfigError(
+                f"Found a `software_sources` key in the config file: {self.path!r}, "
+                f"which indicates the file was created by a very old version (<= 0.2.27) "
+                f"of MatFlow. Please rename or delete this file, or its parent directory:"
+                f" {self.directory!r}."
+            )
 
         self.__contents = contents
         self.__data = data

--- a/hpcflow/sdk/config/errors.py
+++ b/hpcflow/sdk/config/errors.py
@@ -18,6 +18,12 @@ class ConfigError(Exception):
     """
 
 
+class IncompatibleConfigError(ConfigError):
+    """
+    Raised when the config file is from an incompatible version of the app.
+    """
+
+
 class ConfigUnknownItemError(ConfigError):
     """
     Raised when the configuration contains an unknown item.


### PR DESCRIPTION
Also try to handle the case where we come across a `~/.hpcflow` (or `~/.matflow`) that was created by very old versions of hpcflow/MatFlow.