### PR TITLE
Improve config overrides

### DIFF
--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -4090,6 +4090,7 @@ class BaseApp(metaclass=Singleton):
         workflow_ref: int | str | Path,
         ref_is_path: str | None = None,
         status: bool = True,
+        quiet: bool = False,
     ) -> None:
         """
         Cancel the execution of a workflow submission.
@@ -4104,7 +4105,7 @@ class BaseApp(metaclass=Singleton):
             Whether to show a live status during cancel.
         """
         path = self._resolve_workflow_reference(str(workflow_ref), ref_is_path)
-        self.Workflow(path).cancel(status=status)
+        self.Workflow(path).cancel(status=status, quiet=quiet)
 
     @staticmethod
     def redirect_std_to_file(*args, **kwargs):

--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -2304,7 +2304,10 @@ class BaseApp(metaclass=Singleton):
 
     @TimeIt.decorator
     def _load_config(
-        self, config_dir: PathLike, config_key: str | None, **overrides
+        self,
+        config_dir: PathLike,
+        config_key: str | None,
+        overrides: dict[str, Any] | None = None,
     ) -> None:
         self.logger.info("Loading configuration.")
         self._ensure_user_data_dir()
@@ -2327,7 +2330,7 @@ class BaseApp(metaclass=Singleton):
             config_key=config_key,
             logger=self.config_logger,
             variables={"app_name": self.name, "app_version": self.version},
-            **overrides,
+            overrides=overrides,
         )
         self.log.update_console_level(self.config.get("log_console_level"))
         log_file_path = self.config.get("log_file_path")
@@ -2349,7 +2352,7 @@ class BaseApp(metaclass=Singleton):
         config_dir: PathLike = None,
         config_key: str | None = None,
         warn: bool = True,
-        **overrides,
+        overrides: dict[str, Any] | None = None,
     ) -> None:
         """
         Load the user's configuration.
@@ -2365,7 +2368,7 @@ class BaseApp(metaclass=Singleton):
         """
         if warn and self.is_config_loaded:
             warnings.warn("Configuration is already loaded; reloading.")
-        self._load_config(config_dir, config_key, **overrides)
+        self._load_config(config_dir, config_key, overrides=overrides)
 
     def unload_config(self) -> None:
         """
@@ -2394,21 +2397,21 @@ class BaseApp(metaclass=Singleton):
         config_dir: PathLike = None,
         config_key: str | None = None,
         warn: bool = True,
-        **overrides,
+        overrides: dict[str, Any] | None = None,
     ) -> None:
         """Reset the config file to defaults, and reload the config."""
         self.logger.info("resetting config")
         self._delete_config_file(config_dir=config_dir)
         self._config = None
         self._config_files = {}
-        self.load_config(config_dir, config_key, warn=warn, **overrides)
+        self.load_config(config_dir, config_key, warn=warn, overrides=overrides)
 
     def reload_config(
         self,
         config_dir: PathLike = None,
         config_key: str | None = None,
         warn: bool = True,
-        **overrides,
+        overrides: dict[str, Any] | None = None,
     ) -> None:
         """
         Reload the configuration. Use if a user has updated the configuration file
@@ -2418,7 +2421,7 @@ class BaseApp(metaclass=Singleton):
             warnings.warn("Configuration is not loaded; loading.")
         self.log.remove_file_handler()
         self._config_files = {}
-        self._load_config(config_dir, config_key, **overrides)
+        self._load_config(config_dir, config_key, overrides=overrides)
 
     @TimeIt.decorator
     def __load_builtin_files_from_nested_package(

--- a/hpcflow/sdk/cli.py
+++ b/hpcflow/sdk/cli.py
@@ -1862,7 +1862,7 @@ def make_cli(app: BaseApp):
                 app.load_config(
                     config_dir=config_dir,
                     config_key=config_key,
-                    **overrides,
+                    overrides=overrides,
                 )
             except ConfigError as err:
                 click.echo(f"{colored(err.__class__.__name__, 'red')}: {err}")

--- a/hpcflow/sdk/cli_common.py
+++ b/hpcflow/sdk/cli_common.py
@@ -219,18 +219,21 @@ submit_quiet_opt = click.option(
     "--quiet",
     help="If True, do not print anything about workflow submission.",
     default=False,
+    is_flag=True,
 )
 #: Standard option
 wait_quiet_opt = click.option(
     "--quiet",
     help="If True, do not print anything (e.g. when jobscripts have completed).",
     default=False,
+    is_flag=True,
 )
 #: Standard option
 cancel_quiet_opt = click.option(
     "--quiet",
     help="If True, do not print anything (e.g. which jobscripts where cancelled).",
     default=False,
+    is_flag=True,
 )
 #: Standard option
 force_arr_opt = click.option(

--- a/hpcflow/sdk/config/config.py
+++ b/hpcflow/sdk/config/config.py
@@ -247,12 +247,12 @@ class Config:
         uid: str | None = None,
         callbacks: dict[str, tuple[GetterCallback, ...]] | None = None,
         variables: dict[str, str] | None = None,
-        **overrides,
+        overrides: dict[str, Any] | None = None,
     ):
         self._app = app
         self._file = config_file
         self._options = options
-        self._overrides = overrides
+        self._overrides = overrides or {}
         self._logger = logger
         self._variables = variables or {}
 
@@ -321,7 +321,10 @@ class Config:
         self._modified_keys: ConfigDescriptor = {}
         self._unset_keys: set[str] = set()
 
-        if any((unknown := name) not in self._configurable_keys for name in overrides):
+        if any(
+            (unknown := name) not in self._configurable_keys
+            for name in self._override_names
+        ):
             raise ConfigUnknownOverrideError(name=unknown)
 
         host_uid, host_uid_file_path = self._get_user_id()
@@ -569,6 +572,11 @@ class Config:
         else:
             super().__setattr__(name, value)
 
+    @property
+    def _override_names(self) -> set[str]:
+        """Get the set of top-level names of the provided overrides paths, if there are any."""
+        return set(over_key.split(".")[0] for over_key in self._overrides)
+
     def _disable_callbacks(self, callbacks: Sequence[str]) -> tuple[
         dict[str, tuple[GetterCallback, ...]],
         dict[str, tuple[SetterCallback, ...]],
@@ -808,8 +816,32 @@ class Config:
         elif name in self._meta_data:
             val = cast("dict", self._meta_data)[name]
 
-        elif include_overrides and name in self._overrides:
-            val = self._overrides[name]
+        elif include_overrides:
+
+            # overrides might be dot-delimited, so retrieve the non-dot-delimted value
+            # first, and merge into it:
+            if name in self._overrides:
+                root_over = deepcopy(self._overrides[name])
+            else:
+                root_over = self._get(
+                    name=name,
+                    include_overrides=False,
+                    callback=callback,
+                    as_str=as_str,
+                    default_value=default_value,
+                    raise_on_missing=raise_on_missing,
+                )
+
+            for over_key, over_val in self._overrides.items():
+                if over_key == name:
+                    continue
+                over_name, *path_prefix = over_key.split(".")
+                if over_name == name:
+                    if root_over is None:
+                        root_over = {}  # assume a mapping rather than a sequence
+                    set_in_container(root_over, path_prefix, over_val)
+
+            val = root_over
 
         elif name in self._unset_keys:
             if raise_on_missing:

--- a/hpcflow/sdk/core/actions.py
+++ b/hpcflow/sdk/core/actions.py
@@ -3462,7 +3462,7 @@ class Action(JSONLike):
         py_main_block_workflow_load = dedent(
             """\
                 app.load_config(
-                    log_file_path=Path(log_path),
+                    overrides={{"log_file_path": Path(log_path)}},
                     config_dir=r"{cfg_dir}",
                     config_key=r"{cfg_invoc_key}",
                 )

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -1998,7 +1998,7 @@ class Jobscript(JSONLike):
         py_main_block_workflow_load = dedent(
             """\
                 app.load_config(
-                    log_file_path=log_path,
+                    overrides={{"log_file_path": log_path}},
                     config_dir=r"{cfg_dir}",
                     config_key=r"{cfg_invoc_key}",
                 )

--- a/hpcflow/tests/conftest.py
+++ b/hpcflow/tests/conftest.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import copy
 from pathlib import Path
 import pytest
 from click.testing import CliRunner
@@ -55,9 +56,13 @@ def isolated_app_config(tmp_path_factory, pytestconfig):
     hf.run_time_info.in_pytest = True
     original_config_dir = hf.config.config_directory
     original_config_key = hf.config.config_key
+
+    # honour config overrides provided via top-level CLI options `--with-config`:
+    overrides = copy.deepcopy(hf.config._overrides)
+
     hf.unload_config()
     new_config_dir = tmp_path_factory.mktemp("app_config")
-    hf.load_config(config_dir=new_config_dir)
+    hf.load_config(config_dir=new_config_dir, overrides=overrides)
 
     if pytestconfig.getoption("--configure-python-env"):
         # for setting up a Python env using the currently active virtual/conda env:
@@ -74,7 +79,11 @@ def isolated_app_config(tmp_path_factory, pytestconfig):
 
     yield
     hf.unload_config()
-    hf.load_config(config_dir=original_config_dir, config_key=original_config_key)
+    hf.load_config(
+        config_dir=original_config_dir,
+        config_key=original_config_key,
+        overrides=overrides,
+    )
     hf.run_time_info.in_pytest = False
 
 

--- a/hpcflow/tests/unit/test_config.py
+++ b/hpcflow/tests/unit/test_config.py
@@ -192,7 +192,11 @@ def test_workflow_template_config_set(modifiable_config, tmp_path):
 
 
 def test_dot_delimited_override(modifiable_config):
-    key = "shells.powershell.defaults.executable"
+    key = (
+        "shells.powershell.defaults.executable"
+        if os.name == "nt"
+        else "shells.bash.defaults.executable"
+    )
     value = "MY_SHELL_EXE"
     hf.unload_config()
     hf.load_config(overrides={key: value})

--- a/hpcflow/tests/unit/test_config.py
+++ b/hpcflow/tests/unit/test_config.py
@@ -189,3 +189,11 @@ def test_workflow_template_config_set(modifiable_config, tmp_path):
 
     # log file level should not have changed:
     assert hf.config.get("log_file_level") == "warning"
+
+
+def test_dot_delimited_override(modifiable_config):
+    key = "shells.powershell.defaults.executable"
+    value = "MY_SHELL_EXE"
+    hf.unload_config()
+    hf.load_config(overrides={key: value})
+    assert hf.config.get(key) == value


### PR DESCRIPTION
- Support dot-delimited config overrides
- Respect config overrides when running tests

Unrelated fix:
- `cancel` command now works (#953)