### PR TITLE
Merge jobscripts in more scenarios

### DIFF
--- a/hpcflow/sdk/app.py
+++ b/hpcflow/sdk/app.py
@@ -205,6 +205,9 @@ if TYPE_CHECKING:
             config: dict[str, Any] | None = None,
             status: bool = True,
             add_submission: bool = False,
+            JS_parallelism: bool = True,
+            force_array: bool = False,
+            min_jobscripts: bool = True,
         ) -> _Workflow | _Submission | None: ...
 
     class _MakeDemoWorkflow(Protocol):
@@ -229,6 +232,9 @@ if TYPE_CHECKING:
             config: dict[str, Any] | None = None,
             status: bool = True,
             add_submission: bool = False,
+            JS_parallelism: bool = True,
+            force_array: bool = False,
+            min_jobscripts: bool = True,
         ) -> _Workflow | _Submission | None: ...
 
     class _MakeAndSubmitWorkflow(Protocol):
@@ -254,6 +260,7 @@ if TYPE_CHECKING:
             resources: dict[str, Any] | None = None,
             config: dict[str, Any] | None = None,
             JS_parallelism: bool | None = None,
+            min_jobscripts: bool = True,
             wait: bool = False,
             add_to_known: bool = True,
             return_idx: bool = False,
@@ -285,6 +292,7 @@ if TYPE_CHECKING:
             resources: dict[str, Any] | None = None,
             config: dict[str, Any] | None = None,
             JS_parallelism: bool | None = None,
+            min_jobscripts: bool = True,
             wait: bool = False,
             add_to_known: bool = True,
             return_idx: bool = False,
@@ -302,6 +310,7 @@ if TYPE_CHECKING:
             self,
             workflow_path: PathLike,
             JS_parallelism: bool | None = None,
+            min_jobscripts: bool = True,
             wait: bool = False,
             return_idx: bool = False,
             tasks: list[int] | None = None,
@@ -1465,6 +1474,20 @@ class BaseApp(metaclass=Singleton):
             If True, display a live status to track workflow creation progress.
         add_submission
             If True, add a submission to the workflow (but do not submit).
+        JS_parallelism
+            If True, allow multiple jobscripts to execute simultaneously. If
+            'scheduled'/'direct', only allow simultaneous execution of scheduled/direct
+            jobscripts. Raises if set to True, 'scheduled', or 'direct', but the store
+            type does not support the `jobscript_parallelism` feature. If not set,
+            jobscript parallelism will be used if the store type supports it, for
+            scheduled jobscripts only.
+        force_array
+            Used to force the use of job arrays, even if the scheduler does not support
+            it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
 
         Returns
         -------
@@ -1536,6 +1559,10 @@ class BaseApp(metaclass=Singleton):
             If True, allow multiple jobscripts to execute simultaneously. Raises if set to
             True but the store type does not support the `jobscript_parallelism` feature. If
             not set, jobscript parallelism will be used if the store type supports it.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         wait: bool
             If True, this command will block until the workflow execution is complete.
         add_to_known: bool
@@ -1622,6 +1649,10 @@ class BaseApp(metaclass=Singleton):
             If True, allow multiple jobscripts to execute simultaneously. Raises if set to
             True but the store type does not support the `jobscript_parallelism` feature. If
             not set, jobscript parallelism will be used if the store type supports it.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         wait: bool
             If True, this command will block until the workflow execution is complete.
         add_to_known: bool
@@ -1662,6 +1693,10 @@ class BaseApp(metaclass=Singleton):
             If True, allow multiple jobscripts to execute simultaneously. Raises if set to
             True but the store type does not support the `jobscript_parallelism` feature. If
             not set, jobscript parallelism will be used if the store type supports it.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         tasks: list[int]
             List of task indices to include in this submission. By default all tasks are
             included.
@@ -2964,6 +2999,9 @@ class BaseApp(metaclass=Singleton):
         config: dict[str, Any] | None = None,
         status: bool = True,
         add_submission: bool = False,
+        JS_parallelism: bool = True,
+        force_array: bool = False,
+        min_jobscripts: bool = True,
     ) -> _Workflow | _Submission | None:
         """
         Generate a new {app_name} workflow from a file or string containing a workflow
@@ -3023,6 +3061,20 @@ class BaseApp(metaclass=Singleton):
             If True, display a live status to track workflow creation progress.
         add_submission
             If True, add a submission to the workflow (but do not submit).
+        JS_parallelism
+            If True, allow multiple jobscripts to execute simultaneously. If
+            'scheduled'/'direct', only allow simultaneous execution of scheduled/direct
+            jobscripts. Raises if set to True, 'scheduled', or 'direct', but the store
+            type does not support the `jobscript_parallelism` feature. If not set,
+            jobscript parallelism will be used if the store type supports it, for
+            scheduled jobscripts only.
+        force_array
+            Used to force the use of job arrays, even if the scheduler does not support
+            it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
 
         Returns
         -------
@@ -3081,7 +3133,12 @@ class BaseApp(metaclass=Singleton):
                 )
             if add_submission:
                 with wk._store.cached_load(), wk.batch_update():
-                    return wk._add_submission(status=status_)
+                    return wk._add_submission(
+                        status=status_,
+                        JS_parallelism=JS_parallelism,
+                        force_array=force_array,
+                        min_jobscripts=min_jobscripts,
+                    )
 
         return wk
 
@@ -3105,6 +3162,7 @@ class BaseApp(metaclass=Singleton):
         resources: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         wait: bool = False,
         add_to_known: bool = True,
         return_idx: bool = False,
@@ -3175,6 +3233,10 @@ class BaseApp(metaclass=Singleton):
             type does not support the `jobscript_parallelism` feature. If not set,
             jobscript parallelism will be used if the store type supports it, for
             scheduled jobscripts only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         wait
             If True, this command will block until the workflow execution is complete.
         add_to_known
@@ -3225,6 +3287,7 @@ class BaseApp(metaclass=Singleton):
         assert isinstance(wk, _Workflow)
         submitted_js = wk.submit(
             JS_parallelism=JS_parallelism,
+            min_jobscripts=min_jobscripts,
             wait=wait,
             add_to_known=add_to_known,
             return_idx=True,
@@ -3257,6 +3320,9 @@ class BaseApp(metaclass=Singleton):
         config: dict[str, Any] | None = None,
         status: bool = True,
         add_submission: bool = False,
+        JS_parallelism: bool = True,
+        force_array: bool = False,
+        min_jobscripts: bool = True,
     ) -> _Workflow | _Submission | None:
         """
         Generate a new {app_name} workflow from a builtin demo workflow template.
@@ -3313,6 +3379,20 @@ class BaseApp(metaclass=Singleton):
             If True, display a live status to track workflow creation progress.
         add_submission
             If True, add a submission to the workflow (but do not submit).
+        JS_parallelism
+            If True, allow multiple jobscripts to execute simultaneously. If
+            'scheduled'/'direct', only allow simultaneous execution of scheduled/direct
+            jobscripts. Raises if set to True, 'scheduled', or 'direct', but the store
+            type does not support the `jobscript_parallelism` feature. If not set,
+            jobscript parallelism will be used if the store type supports it, for
+            scheduled jobscripts only.
+        force_array
+            Used to force the use of job arrays, even if the scheduler does not support
+            it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
 
         Returns
         -------
@@ -3351,7 +3431,13 @@ class BaseApp(metaclass=Singleton):
             if add_submission:
                 with wk._store.cached_load():
                     with wk.batch_update():
-                        return wk._add_submission(status=status_)
+                        return wk._add_submission(
+                            status=status_,
+                            JS_parallelism=JS_parallelism,
+                            force_array=force_array,
+                            min_jobscripts=min_jobscripts,
+                        )
+
             return wk
 
     @batch_warnings
@@ -3373,6 +3459,7 @@ class BaseApp(metaclass=Singleton):
         resources: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         wait: bool = False,
         add_to_known: bool = True,
         return_idx: bool = False,
@@ -3440,6 +3527,10 @@ class BaseApp(metaclass=Singleton):
             type does not support the `jobscript_parallelism` feature. If not set,
             jobscript parallelism will be used if the store type supports it, for
             scheduled jobscripts only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         wait
             If True, this command will block until the workflow execution is complete.
         add_to_known
@@ -3488,6 +3579,7 @@ class BaseApp(metaclass=Singleton):
         assert isinstance(wk, _Workflow)
         submitted_js = wk.submit(
             JS_parallelism=JS_parallelism,
+            min_jobscripts=min_jobscripts,
             wait=wait,
             add_to_known=add_to_known,
             return_idx=True,
@@ -3505,6 +3597,7 @@ class BaseApp(metaclass=Singleton):
         self,
         workflow_path: PathLike,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         wait: bool = False,
         return_idx: bool = False,
         tasks: list[int] | None = None,
@@ -3524,6 +3617,10 @@ class BaseApp(metaclass=Singleton):
             type does not support the `jobscript_parallelism` feature. If not set,
             jobscript parallelism will be used if the store type supports it, for
             scheduled jobscripts only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         wait:
             Whether to wait for the submission to complete.
         return_idx:
@@ -3545,6 +3642,7 @@ class BaseApp(metaclass=Singleton):
         if return_idx:
             return wk.submit(
                 JS_parallelism=JS_parallelism,
+                min_jobscripts=min_jobscripts,
                 wait=wait,
                 return_idx=True,
                 tasks=tasks,

--- a/hpcflow/sdk/cli.py
+++ b/hpcflow/sdk/cli.py
@@ -41,6 +41,7 @@ from hpcflow.sdk.cli_common import (
     wait_quiet_opt,
     cancel_quiet_opt,
     force_arr_opt,
+    min_jobscripts_opt,
     make_status_opt,
     add_sub_opt,
     zip_path_opt,
@@ -187,6 +188,9 @@ def _make_API_CLI(app: BaseApp):
     @template_config_opt
     @make_status_opt
     @add_sub_opt
+    @js_parallelism_option
+    @force_arr_opt
+    @min_jobscripts_opt
     def make_workflow(
         template_file_or_str: str,
         string: bool,
@@ -205,6 +209,9 @@ def _make_API_CLI(app: BaseApp):
         config: list[tuple[str, str]] | None = None,
         status: bool = True,
         add_submission: bool = False,
+        js_parallelism: bool = True,
+        force_array: bool = False,
+        min_jobscripts: bool = True,
     ):
         """Generate a new {app_name} workflow.
 
@@ -230,6 +237,9 @@ def _make_API_CLI(app: BaseApp):
             config=dict(config) if config is not None else None,
             status=status,
             add_submission=add_submission,
+            JS_parallelism=js_parallelism,
+            force_array=force_array,
+            min_jobscripts=min_jobscripts,
         )
         if add_submission:
             assert isinstance(wk_or_sub, Submission)
@@ -255,6 +265,7 @@ def _make_API_CLI(app: BaseApp):
     @template_resource_opt
     @template_config_opt
     @js_parallelism_option
+    @min_jobscripts_opt
     @wait_option
     @add_to_known_opt
     @print_idx_opt
@@ -279,6 +290,7 @@ def _make_API_CLI(app: BaseApp):
         resources: list[tuple[str, str]] | None = None,
         config: list[tuple[str, str]] | None = None,
         js_parallelism: bool | None = None,
+        min_jobscripts: bool = True,
         wait: bool = False,
         add_to_known: bool = True,
         print_idx: bool = False,
@@ -311,6 +323,7 @@ def _make_API_CLI(app: BaseApp):
             resources=dict(resources) if resources is not None else None,
             config=dict(config) if config is not None else None,
             JS_parallelism=js_parallelism,
+            min_jobscripts=min_jobscripts,
             wait=wait,
             add_to_known=add_to_known,
             return_idx=print_idx,
@@ -569,20 +582,23 @@ def _make_workflow_CLI(app: BaseApp):
     @js_parallelism_option
     @tasks_opt
     @force_arr_opt
+    @min_jobscripts_opt
     @submit_status_opt
-    @click.pass_context
+    @_pass_workflow
     def add_submission(
-        ctx,
+        wf: Workflow,
         js_parallelism=None,
         tasks=None,
         force_array=False,
+        min_jobscripts=True,
         status=True,
     ):
         """Add a new submission to the workflow, but do not submit."""
-        ctx.obj["workflow"].add_submission(
+        wf.add_submission(
             JS_parallelism=js_parallelism,
             tasks=tasks,
             force_array=force_array,
+            min_jobscripts=min_jobscripts,
             status=status,
         )
 

--- a/hpcflow/sdk/cli_common.py
+++ b/hpcflow/sdk/cli_common.py
@@ -245,6 +245,16 @@ force_arr_opt = click.option(
     is_flag=True,
     default=False,
 )
+#: Standard option
+min_jobscripts_opt = click.option(
+    "--min-jobscripts/--no-min-jobscripts",
+    help=(
+        "Minimise the total number of jobscripts by performing as many merges as "
+        "possible. This may merge otherwise independent jobscripts, such that they are "
+        "run sequentially rather than in parallel."
+    ),
+    default=True,
+)
 
 #: Standard option
 make_status_opt = click.option(
@@ -460,6 +470,7 @@ _add_doc_from_help(
     wait_quiet_opt,
     cancel_quiet_opt,
     force_arr_opt,
+    min_jobscripts_opt,
     make_status_opt,
     zip_path_opt,
     zip_overwrite_opt,

--- a/hpcflow/sdk/core/workflow.py
+++ b/hpcflow/sdk/core/workflow.py
@@ -3634,7 +3634,6 @@ class Workflow(AppAware):
         status: Status | None = None,
         ignore_errors: bool = False,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
-        force_array: bool = False,
         min_jobscripts: bool = True,
         print_stdout: bool = False,
         add_to_known: bool = True,
@@ -3645,9 +3644,13 @@ class Workflow(AppAware):
 
         Parameters
         ----------
-        force_array
-            Used to force the use of job arrays, even if the scheduler does not support
-            it. This is provided for testing purposes only.
+        JS_parallelism
+            If True, allow multiple jobscripts to execute simultaneously. If
+            'scheduled'/'direct', only allow simultaneous execution of scheduled/direct
+            jobscripts. Raises if set to True, 'scheduled', or 'direct', but the store
+            type does not support the `jobscript_parallelism` feature. If not set,
+            jobscript parallelism will be used if the store type supports it, for
+            scheduled jobscripts only.
         min_jobscripts
             If True (the default), minimise the total number of jobscripts by performing
             as many merges as possible. This may merge otherwise independent jobscripts,
@@ -3662,7 +3665,6 @@ class Workflow(AppAware):
                 new_sub := self._add_submission(
                     tasks=tasks,
                     JS_parallelism=JS_parallelism,
-                    force_array=force_array,
                     min_jobscripts=min_jobscripts,
                     status=status,
                 )
@@ -3707,6 +3709,7 @@ class Workflow(AppAware):
         *,
         ignore_errors: bool = False,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         print_stdout: bool = False,
         wait: bool = False,
         add_to_known: bool = True,
@@ -3723,6 +3726,7 @@ class Workflow(AppAware):
         *,
         ignore_errors: bool = False,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         print_stdout: bool = False,
         wait: bool = False,
         add_to_known: bool = True,
@@ -3738,6 +3742,7 @@ class Workflow(AppAware):
         *,
         ignore_errors: bool = False,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        min_jobscripts: bool = True,
         print_stdout: bool = False,
         wait: bool = False,
         add_to_known: bool = True,
@@ -3761,6 +3766,10 @@ class Workflow(AppAware):
             type does not support the `jobscript_parallelism` feature. If not set,
             jobscript parallelism will be used if the store type supports it, for
             scheduled jobscripts only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         print_stdout
             If True, print any jobscript submission standard output, otherwise hide it.
         wait
@@ -3801,6 +3810,7 @@ class Workflow(AppAware):
                 exceptions, submitted_js = self._submit(
                     ignore_errors=ignore_errors,
                     JS_parallelism=JS_parallelism,
+                    min_jobscripts=min_jobscripts,
                     print_stdout=print_stdout,
                     status=status_,
                     add_to_known=add_to_known,

--- a/hpcflow/sdk/core/workflow.py
+++ b/hpcflow/sdk/core/workflow.py
@@ -3634,12 +3634,25 @@ class Workflow(AppAware):
         status: Status | None = None,
         ignore_errors: bool = False,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
+        force_array: bool = False,
+        min_jobscripts: bool = True,
         print_stdout: bool = False,
         add_to_known: bool = True,
         tasks: Sequence[int] | None = None,
         quiet: bool = False,
     ) -> tuple[Sequence[SubmissionFailure], Mapping[int, Sequence[int]]]:
-        """Submit outstanding EARs for execution."""
+        """Submit outstanding EARs for execution.
+
+        Parameters
+        ----------
+        force_array
+            Used to force the use of job arrays, even if the scheduler does not support
+            it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
+        """
 
         # generate a new submission if there are no pending submissions:
         if not (pending := [sub for sub in self.submissions if sub.needs_submit]):
@@ -3649,6 +3662,8 @@ class Workflow(AppAware):
                 new_sub := self._add_submission(
                     tasks=tasks,
                     JS_parallelism=JS_parallelism,
+                    force_array=force_array,
+                    min_jobscripts=min_jobscripts,
                     status=status,
                 )
             ):
@@ -4054,6 +4069,7 @@ class Workflow(AppAware):
         tasks: list[int] | None = None,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
         force_array: bool = False,
+        min_jobscripts: bool = True,
         status: bool = True,
     ) -> Submission | None:
         """Add a new submission.
@@ -4063,6 +4079,10 @@ class Workflow(AppAware):
         force_array
             Used to force the use of job arrays, even if the scheduler does not support
             it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         """
         # JS_parallelism=None means guess
         # Type hint for mypy
@@ -4070,7 +4090,9 @@ class Workflow(AppAware):
             rich.console.Console().status("") if status else nullcontext()
         )
         with status_context as status_, self._store.cached_load(), self.batch_update():
-            return self._add_submission(tasks, JS_parallelism, force_array, status_)
+            return self._add_submission(
+                tasks, JS_parallelism, force_array, min_jobscripts, status_
+            )
 
     @TimeIt.decorator
     @load_workflow_config
@@ -4079,6 +4101,7 @@ class Workflow(AppAware):
         tasks: Sequence[int] | None = None,
         JS_parallelism: bool | Literal["direct", "scheduled"] | None = None,
         force_array: bool = False,
+        min_jobscripts: bool = True,
         status: Status | None = None,
     ) -> Submission | None:
         """Add a new submission.
@@ -4088,6 +4111,10 @@ class Workflow(AppAware):
         force_array
             Used to force the use of job arrays, even if the scheduler does not support
             it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
         """
         new_idx = self.num_submissions
         _ = self.submissions  # TODO: just to ensure `submissions` is loaded
@@ -4100,7 +4127,7 @@ class Workflow(AppAware):
         sub_obj: Submission = self._app.Submission(
             index=new_idx,
             workflow=self,
-            jobscripts=self.resolve_jobscripts(cache, tasks, force_array),
+            jobscripts=self.resolve_jobscripts(cache, tasks, force_array, min_jobscripts),
             JS_parallelism=JS_parallelism,
         )
         if status:
@@ -4176,6 +4203,7 @@ class Workflow(AppAware):
         cache: ObjectCache,
         tasks: Sequence[int] | None = None,
         force_array: bool = False,
+        min_jobscripts: bool = True,
     ) -> list[Jobscript]:
         """
         Resolve this workflow to a set of jobscripts to run for a new submission.
@@ -4185,6 +4213,10 @@ class Workflow(AppAware):
         force_array
             Used to force the use of job arrays, even if the scheduler does not support
             it. This is provided for testing purposes only.
+        min_jobscripts
+            If True (the default), minimise the total number of jobscripts by performing
+            as many merges as possible. This may merge otherwise independent jobscripts,
+            such that they are run sequentially rather than in parallel.
 
         """
         with self._app.config.cached_config():
@@ -4199,7 +4231,9 @@ class Workflow(AppAware):
                 if js_idx in js_deps:
                     jsca["dependencies"] = js_deps[js_idx]  # type: ignore
 
-            js = merge_jobscripts_across_tasks(js)
+            js = merge_jobscripts_across_tasks(
+                js, min_jobscripts, logger=self._app.submission_logger
+            )
 
             # for direct or (non-array scheduled), combine into jobscripts of multiple
             # blocks for dependent jobscripts that have the same resource hashes

--- a/hpcflow/sdk/demo/cli.py
+++ b/hpcflow/sdk/demo/cli.py
@@ -34,6 +34,8 @@ from hpcflow.sdk.cli_common import (
     template_updates_opt,
     template_resource_opt,
     template_config_opt,
+    force_arr_opt,
+    min_jobscripts_opt,
 )
 from hpcflow.sdk.submission.submission import Submission
 
@@ -132,6 +134,8 @@ def get_demo_workflow_CLI(app: BaseApp):
     @template_config_opt
     @make_status_opt
     @add_sub_opt
+    @force_arr_opt
+    @min_jobscripts_opt
     def make_demo_workflow(
         workflow_name: str,
         format: Literal["json", "yaml"] | None,
@@ -149,6 +153,8 @@ def get_demo_workflow_CLI(app: BaseApp):
         config: list[tuple[str, str]] | None = None,
         status: bool = True,
         add_submission: bool = False,
+        force_array: bool = False,
+        min_jobscripts: bool = True,
     ):
         wk_or_sub = app.make_demo_workflow(
             workflow_name=workflow_name,
@@ -167,6 +173,8 @@ def get_demo_workflow_CLI(app: BaseApp):
             config=dict(config) if config is not None else None,
             status=status,
             add_submission=add_submission,
+            force_array=force_array,
+            min_jobscripts=min_jobscripts,
         )
         if add_submission:
             assert isinstance(wk_or_sub, Submission)
@@ -191,6 +199,7 @@ def get_demo_workflow_CLI(app: BaseApp):
     @template_resource_opt
     @template_config_opt
     @js_parallelism_option
+    @min_jobscripts_opt
     @wait_option
     @add_to_known_opt
     @print_idx_opt
@@ -214,6 +223,7 @@ def get_demo_workflow_CLI(app: BaseApp):
         resources: list[tuple[str, str]] | None = None,
         config: list[tuple[str, str]] | None = None,
         js_parallelism: bool | None = None,
+        min_jobscripts: bool = True,
         wait: bool = False,
         add_to_known: bool = True,
         print_idx: bool = False,
@@ -238,6 +248,7 @@ def get_demo_workflow_CLI(app: BaseApp):
             resources=dict(resources) if resources is not None else None,
             config=dict(config) if config is not None else None,
             JS_parallelism=js_parallelism,
+            min_jobscripts=min_jobscripts,
             wait=wait,
             add_to_known=add_to_known,
             return_idx=print_idx,

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -273,14 +273,19 @@ def resolve_jobscript_dependencies(
             js_i_num_js_elements = jobscripts[js_i_idx]["EAR_ID"].shape[1]
             js_k_num_js_elements = jobscripts[js_k_idx]["EAR_ID"].shape[1]
 
+            # is there a dependency for each jobscript element?
             is_all_i_elems = sorted(set(deps_j["js_element_mapping"])) == list(
                 range(js_i_num_js_elements)
             )
 
+            # does each jobscript element depend on exactly one jobscript element from the
+            # other jobscript?
             is_all_k_single = set(
                 len(i) for i in deps_j["js_element_mapping"].values()
             ) == {1}
 
+            # is each jobscript element in the dependency jobscript associated with an
+            # element in the dependent jobscript?
             is_all_k_elems = sorted(
                 i[0] for i in deps_j["js_element_mapping"].values()
             ) == list(range(js_k_num_js_elements))
@@ -337,8 +342,20 @@ def merge_jobscripts_across_tasks(
                         f"dependencies."
                     )
                 continue
+            else:
+                # aiming to merge this jobscript with the previous jobscript, even though
+                # it has no dependency relationship; skip if not compatible (equal number
+                # of elements):
+                if not (
+                    js["EAR_ID"].shape[1] == jobscripts[js_idx - 1]["EAR_ID"].shape[1]
+                ):
+                    logger.info(
+                        f"not considering merge of jobscript {js_idx!r} due to "
+                        f"different numbers of elements."
+                    )
+                    continue
 
-        closest_idx = cast("int", max(js["dependencies"]))
+        closest_idx = cast("int", max(js["dependencies"], default=js_idx - 1))
         closest_js = jobscripts[closest_idx]
         other_deps = {k: v for k, v in js["dependencies"].items() if k != closest_idx}
 
@@ -378,16 +395,23 @@ def merge_jobscripts_across_tasks(
                         if logger:
                             logger.info(f"considering merge of jobscript {js_idx!r}.")
                         deps_to_add[dep_idx] = dep_i
+                else:
+                    merge_possible = False
+                    break
 
         if merge_possible:
             js_j = closest_js  # the jobscript we are merging `js` into
             js_j_idx = closest_idx
-            dep_info = js["dependencies"][js_j_idx]
+            if dep_info := js["dependencies"].get(js_j_idx):
+                # can only merge if it's an array dependency
+                dep_compat = dep_info["is_array"]
+            else:
+                # i.e. merging independent jobscripts
+                dep_compat = True
 
-            # can only merge if resources are the same and is array dependency:
-            if (res_equal := js["resource_hash"] == js_j["resource_hash"]) and (
-                dep_is_arr := dep_info["is_array"]
-            ):
+            # can only merge if resources are the same:
+            res_equal = js["resource_hash"] == js_j["resource_hash"]
+            if res_equal and dep_compat:
                 if logger:
                     logger.info(
                         f"merging jobscript {js_idx!r} into jobscript {js_j_idx}."
@@ -423,7 +447,7 @@ def merge_jobscripts_across_tasks(
             elif logger:
                 logger.info(
                     f"cannot merge jobscript {js_idx!r} into jobscript {js_j_idx}: "
-                    f"res_equal={res_equal!r}; dep_is_arr={dep_is_arr!r}."
+                    f"res_equal={res_equal!r}; dep_compat={dep_compat!r}."
                 )
 
     # remove is_merged jobscripts:

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -308,11 +308,20 @@ def _reindex_dependencies(
 @TimeIt.decorator
 def merge_jobscripts_across_tasks(
     jobscripts: Mapping[int, JobScriptCreationArguments],
+    min_jobscripts: bool = True,
+    logger: logging.Logger | None = None,
 ) -> Mapping[int, JobScriptCreationArguments]:
     """Try to merge jobscripts between tasks.
 
     This is possible if two jobscripts share the same resources and have an array
     dependency (i.e. one-to-one element dependency mapping).
+
+    Parameters
+    ----------
+    min_jobscripts
+        If True (the default), minimise the total number of jobscripts by performing as
+        many merges as possible. This may merge otherwise independent jobscripts, such
+        that they are run sequentially rather than in parallel.
 
     """
 
@@ -322,29 +331,63 @@ def merge_jobscripts_across_tasks(
 
     for js_idx, js in jobscripts.items():
         if not js["dependencies"]:
-            continue
+            if js_idx == 0 or not min_jobscripts:
+                if logger:
+                    logger.info(
+                        f"not considering merge of jobscript {js_idx!r} due to no "
+                        f"dependencies."
+                    )
+                continue
 
         closest_idx = cast("int", max(js["dependencies"]))
         closest_js = jobscripts[closest_idx]
         other_deps = {k: v for k, v in js["dependencies"].items() if k != closest_idx}
 
-        # if all `other_deps` are also found within `closest_js`'s dependencies, then we
-        # can merge `js` into `closest_js`:
-        merge = True
+        # first check if jobscript dependencies are compatible with merging:
+        merge_possible = True
+        deps_to_add = {}
         for dep_idx, dep_i in other_deps.items():
             try:
-                if closest_js["dependencies"][dep_idx] != dep_i:
-                    merge = False
+                if (closest_dep := closest_js["dependencies"][dep_idx]) != dep_i:
+                    if logger:
+                        logger.info(
+                            f"not considering merge of jobscript {js_idx!r} due to "
+                            f"incompatible dependencies: dependency of this jobscript: "
+                            f"{dep_i!r} is not compatible with the same dependency in "
+                            f"the closest jobscript: {closest_dep!r}"
+                        )
+                    merge_possible = False
+                    break
             except KeyError:
-                merge = False
+                # current jobscript (`js_idx`) depends on a jobscript that `closest_js`
+                # does not depend on; this doesn't prohibit merging, but we need to
+                # check that the `js_element_mapping` is the same, and also add the
+                # dependency from `js_idx` if merging into `closest_js`:
+                if min_jobscripts:
+                    if js["dependencies"][closest_idx] != dep_i:
+                        logger.info(
+                            f"not consider merge of jobscript {js_idx!r}; it depends on "
+                            f"a jobscript ({dep_idx!r}) that the closest jobscript does "
+                            f"not depend on, and that dependency is not compatible with "
+                            f"the dependencies of the closest jobscript."
+                        )
+                        merge_possible = False
+                        break
+                    else:
+                        logger.info(f"considering merge of jobscript {js_idx!r}.")
+                        deps_to_add[dep_idx] = dep_i
 
-        if merge:
+        if merge_possible:
             js_j = closest_js  # the jobscript we are merging `js` into
             js_j_idx = closest_idx
             dep_info = js["dependencies"][js_j_idx]
 
             # can only merge if resources are the same and is array dependency:
-            if js["resource_hash"] == js_j["resource_hash"] and dep_info["is_array"]:
+            if (res_equal := js["resource_hash"] == js_j["resource_hash"]) and (
+                dep_is_arr := dep_info["is_array"]
+            ):
+                logger.info(f"merging jobscript {js_idx!r} into jobscript {js_j_idx}.")
+
                 num_loop_idx = len(
                     js_j["task_loop_idx"]
                 )  # TODO: should this be: `js_j["task_loop_idx"][0]`?
@@ -365,8 +408,18 @@ def merge_jobscripts_across_tasks(
                 # mark this js as defunct
                 merged.add(id(js))
 
+                # add dependencies that were defined current jobscript (`js_idx`) but not
+                # in `js_j`:
+                js_j["dependencies"].update(deps_to_add)
+
                 # update dependencies of any downstream jobscripts that refer to this js
                 _reindex_dependencies(jobscripts, js_idx, js_j_idx)
+
+            else:
+                logger.info(
+                    f"cannot merge jobscript {js_idx!r} into jobscript {js_j_idx}: "
+                    f"res_equal={res_equal!r}; dep_is_arr={dep_is_arr!r}."
+                )
 
     # remove is_merged jobscripts:
     return {k: v for k, v in jobscripts.items() if id(v) not in merged}

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -349,10 +349,11 @@ def merge_jobscripts_across_tasks(
                 if not (
                     js["EAR_ID"].shape[1] == jobscripts[js_idx - 1]["EAR_ID"].shape[1]
                 ):
-                    logger.info(
-                        f"not considering merge of jobscript {js_idx!r} due to "
-                        f"different numbers of elements."
-                    )
+                    if logger:
+                        logger.info(
+                            f"not considering merge of jobscript {js_idx!r} due to "
+                            f"different numbers of elements."
+                        )
                     continue
 
         closest_idx = cast("int", max(js["dependencies"], default=js_idx - 1))

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -375,7 +375,8 @@ def merge_jobscripts_across_tasks(
                         merge_possible = False
                         break
                     else:
-                        logger.info(f"considering merge of jobscript {js_idx!r}.")
+                        if logger:
+                            logger.info(f"considering merge of jobscript {js_idx!r}.")
                         deps_to_add[dep_idx] = dep_i
 
         if merge_possible:

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -383,7 +383,7 @@ def merge_jobscripts_across_tasks(
                     if js["dependencies"][closest_idx] != dep_i:
                         if logger:
                             logger.info(
-                                f"not consider merge of jobscript {js_idx!r}; it depends "
+                                f"not considering merge of jobscript {js_idx!r}; it depends "
                                 f"on a jobscript ({dep_idx!r}) that the closest "
                                 f"jobscript does not depend on, and that dependency is "
                                 f"not compatible with the dependencies of the closest "
@@ -396,6 +396,13 @@ def merge_jobscripts_across_tasks(
                             logger.info(f"considering merge of jobscript {js_idx!r}.")
                         deps_to_add[dep_idx] = dep_i
                 else:
+                    if logger:
+                        logger.info(
+                            f"not considering merge of jobscript {js_idx!r}; it depends "
+                            f"on a jobscript ({dep_idx!r}) that the closest "
+                            f"jobscript does not depend on. Use `min_jobscripts=True` to "
+                            f"attempt to merge in this scenario."
+                        )
                     merge_possible = False
                     break
 

--- a/hpcflow/sdk/submission/jobscript.py
+++ b/hpcflow/sdk/submission/jobscript.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 from collections import defaultdict
 
 import os
-import shutil
-import socket
+import logging
 import subprocess
 from textwrap import dedent, indent
 from typing import TextIO, cast, overload, TYPE_CHECKING
@@ -365,12 +364,14 @@ def merge_jobscripts_across_tasks(
                 # dependency from `js_idx` if merging into `closest_js`:
                 if min_jobscripts:
                     if js["dependencies"][closest_idx] != dep_i:
-                        logger.info(
-                            f"not consider merge of jobscript {js_idx!r}; it depends on "
-                            f"a jobscript ({dep_idx!r}) that the closest jobscript does "
-                            f"not depend on, and that dependency is not compatible with "
-                            f"the dependencies of the closest jobscript."
-                        )
+                        if logger:
+                            logger.info(
+                                f"not consider merge of jobscript {js_idx!r}; it depends "
+                                f"on a jobscript ({dep_idx!r}) that the closest "
+                                f"jobscript does not depend on, and that dependency is "
+                                f"not compatible with the dependencies of the closest "
+                                f"jobscript."
+                            )
                         merge_possible = False
                         break
                     else:
@@ -386,7 +387,10 @@ def merge_jobscripts_across_tasks(
             if (res_equal := js["resource_hash"] == js_j["resource_hash"]) and (
                 dep_is_arr := dep_info["is_array"]
             ):
-                logger.info(f"merging jobscript {js_idx!r} into jobscript {js_j_idx}.")
+                if logger:
+                    logger.info(
+                        f"merging jobscript {js_idx!r} into jobscript {js_j_idx}."
+                    )
 
                 num_loop_idx = len(
                     js_j["task_loop_idx"]
@@ -415,7 +419,7 @@ def merge_jobscripts_across_tasks(
                 # update dependencies of any downstream jobscripts that refer to this js
                 _reindex_dependencies(jobscripts, js_idx, js_j_idx)
 
-            else:
+            elif logger:
                 logger.info(
                     f"cannot merge jobscript {js_idx!r} into jobscript {js_j_idx}: "
                     f"res_equal={res_equal!r}; dep_is_arr={dep_is_arr!r}."

--- a/hpcflow/tests/unit/test_jobscript_unit.py
+++ b/hpcflow/tests/unit/test_jobscript_unit.py
@@ -387,7 +387,7 @@ def test_multi_block_jobscript_multi_dependence_distinct_resources(tmp_path):
     assert len(sub.jobscripts) == 3
     assert len(sub.jobscripts[0].blocks) == 1
     assert len(sub.jobscripts[1].blocks) == 1
-    assert len(sub.jobscripts[2].blocks) == 2
+    assert len(sub.jobscripts[2].blocks) == 1
 
 
 def test_multi_block_jobscript_multi_dependence_distinct_resources_sequence_and_group(

--- a/hpcflow/tests/unit/test_jobscript_unit.py
+++ b/hpcflow/tests/unit/test_jobscript_unit.py
@@ -755,3 +755,72 @@ def test_jobscript_dependencies_equivalence_JSON_Zarr(tmp_path):
         for blk_idx, js_blk_zarr in enumerate(js_zarr.blocks):
             js_blk_json = sub_json.jobscripts[js_idx].blocks[blk_idx]
             assert js_blk_zarr.dependencies == js_blk_json.dependencies
+
+
+def test_min_jobscripts_false(tmp_path):
+    s1, s2, s3, s4 = make_schemas(
+        ({}, ("p2",), "t1"),
+        ({"p3": None}, ("p4",), "t2"),  # does not depend on t1
+        ({"p4": None}, ("p5",), "t3"),
+        ({"p2": None, "p5": None}, tuple(), "t4"),  # does not depend on t2
+    )
+    wk = hf.Workflow.from_template_data(
+        template_name="test_merge_js",
+        workflow_name="test_merge_js",
+        path=tmp_path,
+        overwrite=True,
+        tasks=[
+            hf.Task(schema=s1, repeats=2),
+            hf.Task(schema=s2, repeats=2),
+            hf.Task(schema=s3),
+            hf.Task(schema=s4),
+        ],
+    )
+    sub = wk.add_submission(status=False, force_array=True, min_jobscripts=False)
+    assert len(sub.jobscripts) == 3
+
+
+def test_min_jobscripts_true(tmp_path):
+    s1, s2, s3, s4 = make_schemas(
+        ({}, ("p2",), "t1"),
+        ({"p3": None}, ("p4",), "t2"),  # does not depend on t1
+        ({"p4": None}, ("p5",), "t3"),
+        ({"p2": None, "p5": None}, tuple(), "t4"),  # does not depend on t2
+    )
+    wk = hf.Workflow.from_template_data(
+        template_name="test_merge_js",
+        workflow_name="test_merge_js",
+        path=tmp_path,
+        overwrite=True,
+        tasks=[
+            hf.Task(schema=s1, repeats=2),
+            hf.Task(schema=s2, repeats=2),
+            hf.Task(schema=s3),
+            hf.Task(schema=s4),
+        ],
+    )
+    sub = wk.add_submission(status=False, force_array=True, min_jobscripts=True)
+    assert len(sub.jobscripts) == 1
+
+
+def test_min_jobscripts_true_non_mergeable(tmp_path):
+    s1, s2, s3, s4 = make_schemas(
+        ({}, ("p2",), "t1"),
+        ({"p3": None}, ("p4",), "t2"),  # does not depend on t1
+        ({"p4": None}, ("p5",), "t3"),
+        ({"p2": None, "p5": None}, tuple(), "t4"),  # does not depend on t2
+    )
+    wk = hf.Workflow.from_template_data(
+        template_name="test_merge_js",
+        workflow_name="test_merge_js",
+        path=tmp_path,
+        overwrite=True,
+        tasks=[
+            hf.Task(schema=s1, repeats=1),
+            hf.Task(schema=s2, repeats=2),  # different number of elements, cannot merge
+            hf.Task(schema=s3),
+            hf.Task(schema=s4),
+        ],
+    )
+    sub = wk.add_submission(status=False, force_array=True, min_jobscripts=True)
+    assert len(sub.jobscripts) == 3


### PR DESCRIPTION
- fix: consistent submission options through the API
- feat: add `min_jobscripts` flag to minimise the number of generated jobscripts (default True)
- docs: add logging to jobscript merging function explaining why a jobscript was or was not merged