### PR TITLE
Try to fix commitizen bumping issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ hpcflow = 'hpcflow.cli:cli'
 hook-dirs = "hpcflow.__pyinstaller:get_hook_dirs"
 
 [tool.commitizen]
-name = "cz_conventional_commits"
+name = "cz_customize"
 version = "0.2.0"
 tag_format = "v$version"
 version_files = [
@@ -109,6 +109,28 @@ version_files = [
     "hpcflow/_version.py"
 ]
 bump_message = "bump: $current_version → $new_version [skip ci]"
+
+[tool.commitizen.customize]
+bump_pattern = "^(BREAKING[ -]CHANGE|feat|fix|build|change|chore|ci|deprecate|docs|perf|refactor|remove|revert|security|style|test)(\\(.+\\))?(!)?:"
+
+[tool.commitizen.customize.bump_map]
+"BREAKING CHANGE" = "MAJOR"
+"BREAKING-CHANGE" = "MAJOR"
+feat = "MINOR"
+fix = "PATCH"
+build = "PATCH"
+change = "PATCH"
+chore = "PATCH"
+ci = "PATCH"
+deprecate = "PATCH"
+docs = "PATCH"
+perf = "PATCH"
+refactor = "PATCH"
+remove = "PATCH"
+revert = "PATCH"
+security = "PATCH"
+style = "PATCH"
+test = "PATCH"
 
 [tool.black]
 line-length = 90


### PR DESCRIPTION
After a "stable" release (e.g. 0.2.0), PRs that merge into develop do not release properly if commitizen can not find any bump-worthy commits. Currently, only feat, fix and BREAKING CHANGE are considered worthy. This is not an issue if the current tag already includes a pre-release descriptor (e.g. 0.2.1a0); commitizen just increments the pre-release part. After a "stable" release, the current tag doesn't include this pre-release part.

This PR aims to tell commitzen to always bump at least by a PATCH level, for all commit types that we consider valid.